### PR TITLE
Option for copy previous user manual

### DIFF
--- a/release_ccharp/cli.py
+++ b/release_ccharp/cli.py
@@ -11,7 +11,7 @@ def cli(ctx, whatif):
 
 @cli.command("create-cand")
 @click.argument("repo")
-@click.option("--major", is_flag=False)
+@click.option("--major", is_flag=True, default=False)
 @click.pass_context
 def create_cand(ctx, repo, major):
     workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo)
@@ -52,10 +52,16 @@ def download_release_history(ctx, repo):
 
 @cli.command("generate-user-manual")
 @click.argument("repo")
+@click.option("--copy-latest", is_flag=True, default=False)
 @click.pass_context
-def generate_user_manual(ctx, repo):
+def generate_user_manual(ctx, repo, copy_latest):
     workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo)
-    workflow.generate_user_manual()
+    if copy_latest:
+        print("Copy user manual from latest accepted directory")
+        workflow.copy_previous_user_manual()
+    else:
+        print("Generate user manual from confluence workspace")
+        workflow.generate_user_manual()
 
 
 def cli_main():

--- a/release_ccharp/exceptions.py
+++ b/release_ccharp/exceptions.py
@@ -1,0 +1,2 @@
+class SnpseqReleaseException(Exception):
+    pass

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -36,7 +36,7 @@ class SnpseqPaths:
         i.e. the path to the download directory (not the doc path)
         :return: 
         """
-        version = str(workflow.get_latest_version())
+        version = str(self._get_current_release_tag(workflow))
         latest_path = self.find_current_release_branch_dir(workflow=workflow)
         manual_base_name = "{}-user-manual".format(self.repo)
         manual_name = "{}-v{}.pdf".format(manual_base_name, version)
@@ -66,3 +66,14 @@ class SnpseqPaths:
         queue = workflow.get_queue()
         branch = queue[0]
         return os.path.join(self.candidate_path, branch)
+
+    def _get_current_release_tag(self, workflow):
+        """
+        Get the version of the latest candidate branch
+        :param workflow: 
+        :return: Version of latest candidate branch
+        """
+        queue = workflow.get_queue()
+        branch = queue[0]
+        tag = Conventions.get_tag_from_branch(branch)
+        return tag

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -14,13 +14,26 @@ class SnpseqPaths:
     def __init__(self, config, repo):
         self.config = config
         self.repo = repo
+        self.workflow = None
 
     @property
     def _repo_root(self):
         return os.path.join(self.config[self.repo]['root_path'], self.repo)
 
     @property
-    def candidate_path(self):
+    def _candidate_tag(self):
+        """
+        Get the version of the latest candidate branch
+        :param workflow: 
+        :return: Version of latest candidate branch
+        """
+        queue = self.workflow.get_queue()
+        branch = queue[0]
+        tag = Conventions.get_tag_from_branch(branch)
+        return tag
+
+    @property
+    def candidate_root_path(self):
         return os.path.join(self._repo_root, candidate_subpath)
 
     @property
@@ -31,57 +44,50 @@ class SnpseqPaths:
     def confluence_tools_config(self):
         return os.path.join(self._repo_root, confluence_tools_subpath)
 
-    def user_manual_download_path(self, workflow):
+    @property
+    def user_manual_download_path(self):
         """
         Generates user manual name for coming version, and use the artifact path,
         i.e. the path to the download directory (not the doc path)
         :return: 
         """
-        version = str(self._candidate_tag(workflow))
-        latest_path = self.find_current_candidate_dir(workflow=workflow)
+        version = str(self._candidate_tag)
+        latest_path = self.current_candidate_dir
         manual_base_name = "{}-user-manual".format(self.repo)
         manual_name = "{}-{}.pdf".format(manual_base_name, version)
         return os.path.join(latest_path, manual_name)
 
-    def user_manual_path_previous(self, workflow):
+    @property
+    def user_manual_path_previous(self):
         manual_base_name = "{}-user-manual".format(self.repo)
-        latest_version = workflow.get_latest_version()
+        latest_version = self.workflow.get_latest_version()
         manual_name = "{}-v{}.pdf".format(manual_base_name, latest_version)
-        latest_path = self.find_previous_download_dir(workflow)
+        latest_path = self.latest_accepted_candidate_dir
         return os.path.join(latest_path, manual_name)
 
-    def find_previous_download_dir(self, workflow):
+    @property
+    def latest_accepted_candidate_dir(self):
         """
         Find the download catalog for the latest accepted branch
         :return: The path of latest accepted branch
         """
-        current_version = workflow.get_latest_version()
-        subdirs = os.listdir(self.candidate_path)
+        current_version = self.workflow.get_latest_version()
+        subdirs = os.listdir(self.candidate_root_path)
         subdir_path = None
         for subdir in subdirs:
             if re.match('(release|hotfix)-{}'.format(current_version), subdir):
-                subdir_path = os.path.join(self.candidate_path, subdir)
+                subdir_path = os.path.join(self.candidate_root_path, subdir)
         if subdir_path is None:
             raise SnpseqReleaseException("Could not find the download catalog for latest version")
         return subdir_path
 
-    def find_current_candidate_dir(self, workflow):
+    @property
+    def current_candidate_dir(self):
         """
         Find the download catalog for the latest candidate branch
         :param workflow: 
         :return: The path of the latest candidate branch
         """
-        queue = workflow.get_queue()
+        queue = self.workflow.get_queue()
         branch = queue[0]
-        return os.path.join(self.candidate_path, branch)
-
-    def _candidate_tag(self, workflow):
-        """
-        Get the version of the latest candidate branch
-        :param workflow: 
-        :return: Version of latest candidate branch
-        """
-        queue = workflow.get_queue()
-        branch = queue[0]
-        tag = Conventions.get_tag_from_branch(branch)
-        return tag
+        return os.path.join(self.candidate_root_path, branch)

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -1,6 +1,7 @@
 import os
 import re
-from snpseq_workflow import *
+from release_ccharp.exceptions import SnpseqReleaseException
+from release_ccharp.snpseq_workflow import *
 
 candidate_subpath = r"candidates"
 release_tools_subpath = r"buildconfig\release-tools.config"
@@ -36,13 +37,20 @@ class SnpseqPaths:
         i.e. the path to the download directory (not the doc path)
         :return: 
         """
-        version = str(self._get_current_release_tag(workflow))
-        latest_path = self.find_current_release_branch_dir(workflow=workflow)
+        version = str(self._candidate_tag(workflow))
+        latest_path = self.find_current_candidate_dir(workflow=workflow)
         manual_base_name = "{}-user-manual".format(self.repo)
-        manual_name = "{}-v{}.pdf".format(manual_base_name, version)
+        manual_name = "{}-{}.pdf".format(manual_base_name, version)
         return os.path.join(latest_path, manual_name)
 
-    def find_latest_download_dir(self, workflow):
+    def user_manual_path_previous(self, workflow):
+        manual_base_name = "{}-user-manual".format(self.repo)
+        latest_version = workflow.get_latest_version()
+        manual_name = "{}-v{}.pdf".format(manual_base_name, latest_version)
+        latest_path = self.find_previous_download_dir(workflow)
+        return os.path.join(latest_path, manual_name)
+
+    def find_previous_download_dir(self, workflow):
         """
         Find the download catalog for the latest accepted branch
         :return: The path of latest accepted branch
@@ -57,7 +65,7 @@ class SnpseqPaths:
             raise SnpseqReleaseException("Could not find the download catalog for latest version")
         return subdir_path
 
-    def find_current_release_branch_dir(self, workflow):
+    def find_current_candidate_dir(self, workflow):
         """
         Find the download catalog for the latest candidate branch
         :param workflow: 
@@ -67,7 +75,7 @@ class SnpseqPaths:
         branch = queue[0]
         return os.path.join(self.candidate_path, branch)
 
-    def _get_current_release_tag(self, workflow):
+    def _candidate_tag(self, workflow):
         """
         Get the version of the latest candidate branch
         :param workflow: 

--- a/release_ccharp/snpseq_workflow.py
+++ b/release_ccharp/snpseq_workflow.py
@@ -24,6 +24,8 @@ class SnpseqWorkflow:
         self.whatif = whatif
         self.repo = repo
         self.paths = SnpseqPaths(self.config, self.repo)
+        self.workflow = self._create_workflow()
+        self.paths.workflow = self.workflow
 
     def _open_config(self, config_file):
         with open(config_file) as f:
@@ -42,31 +44,30 @@ class SnpseqWorkflow:
         return Workflow(provider, Conventions, whatif)
 
     def create_cand(self, major_inc=False):
-        wf = self._create_workflow()
-        wf.create_release_candidate(major_inc)
+        self.workflow.create_release_candidate(major_inc)
 
     def create_hotfix(self):
-        wf = self._create_workflow()
-        wf.create_hotfix()
+        self.workflow.create_hotfix()
 
     def download(self):
-        wf = self._create_workflow()
-        wf.download_next_in_queue(path=self.paths.candidate_path, force=False)
+        self.workflow.download_next_in_queue(path=self.paths.candidate_root_path, force=False)
 
     def accept(self):
-        wf = self._create_workflow()
-        wf.accept_release_candidate(force=False)
+        self.workflow.accept_release_candidate(force=False)
 
     def download_release_history(self):
-        wf = self._create_workflow()
-        latest_path = self.paths.find_previous_download_dir(workflow=wf)
+        """
+        Should be called after the candidate is accepted and the release history is 
+        updated on GitHub        
+        :return: 
+        """
+        latest_path = self.paths.latest_accepted_candidate_dir
         path = os.path.join(latest_path, "release-history.txt")
-        wf.download_release_history(path=path)
+        self.workflow.download_release_history(path=path)
 
     def generate_user_manual(self):
         space_key = self.config[self.repo]["confluence_space_key"]
-        wf = self._create_workflow()
-        user_manual = self.paths.user_manual_download_path(workflow=wf)
+        user_manual = self.paths.user_manual_download_path
         cmd = ["confluence-tools",
                 "--config",
                 self.paths.confluence_tools_config,
@@ -77,9 +78,8 @@ class SnpseqWorkflow:
             call(cmd)
 
     def copy_previous_user_manual(self):
-        workflow = self._create_workflow()
-        latest_manual = self.paths.user_manual_path_previous(workflow)
-        next_manual = self.paths.user_manual_download_path(workflow)
+        latest_manual = self.paths.user_manual_path_previous
+        next_manual = self.paths.user_manual_download_path
         if not os.path.exists(latest_manual):
             raise SnpseqReleaseException("Previous user manual could not be found: {}".format(latest_manual))
         if not self.whatif:

--- a/tests/wf_tests.py
+++ b/tests/wf_tests.py
@@ -60,7 +60,13 @@ class WorkflowTests(unittest.TestCase):
         self.workflow.generate_user_manual()
         self.assertEqual(1,2)
 
+    @unittest.skip("")
     def test_find_current_release_dir(self):
         wf = self.workflow._create_workflow()
         path = self.workflow.paths.find_current_release_branch_dir(workflow=wf)
         self.assertEqual("xxx", path)
+
+    def test_get_current_release_tag(self):
+        wf = self.workflow._create_workflow()
+        tag = self.workflow.paths._get_current_release_tag(wf)
+        self.assertEqual("xxx", tag)

--- a/tests/wf_tests.py
+++ b/tests/wf_tests.py
@@ -63,10 +63,14 @@ class WorkflowTests(unittest.TestCase):
     @unittest.skip("")
     def test_find_current_release_dir(self):
         wf = self.workflow._create_workflow()
-        path = self.workflow.paths.find_current_release_branch_dir(workflow=wf)
+        path = self.workflow.paths.find_current_candidate_dir(workflow=wf)
         self.assertEqual("xxx", path)
 
+    @unittest.skip("")
     def test_get_current_release_tag(self):
         wf = self.workflow._create_workflow()
-        tag = self.workflow.paths._get_current_release_tag(wf)
+        tag = self.workflow.paths._candidate_tag(wf)
         self.assertEqual("xxx", tag)
+
+    def test_copy_manual(self):
+        self.workflow.copy_previous_user_manual()

--- a/tests/wf_tests.py
+++ b/tests/wf_tests.py
@@ -27,6 +27,15 @@ class WorkflowTests(unittest.TestCase):
         self.assertEqual(1,2)
 
     @unittest.skip("")
+    def test_generate_manual(self):
+        self.workflow.generate_user_manual()
+        self.assertEqual(1,2)
+
+    @unittest.skip("")
+    def test_copy_manual(self):
+        self.workflow.copy_previous_user_manual()
+
+    @unittest.skip("")
     def test_accept(self):
         self.workflow.accept()
         self.assertEqual(1,2)
@@ -56,21 +65,13 @@ class WorkflowTests(unittest.TestCase):
         self.assertEqual(1,2)
 
     @unittest.skip("")
-    def test_generate_manual(self):
-        self.workflow.generate_user_manual()
-        self.assertEqual(1,2)
-
-    @unittest.skip("")
     def test_find_current_release_dir(self):
         wf = self.workflow._create_workflow()
-        path = self.workflow.paths.find_current_candidate_dir(workflow=wf)
+        path = self.workflow.paths.current_candidate_dir
         self.assertEqual("xxx", path)
 
     @unittest.skip("")
     def test_get_current_release_tag(self):
         wf = self.workflow._create_workflow()
-        tag = self.workflow.paths._candidate_tag(wf)
+        tag = self.workflow.paths._candidate_tag
         self.assertEqual("xxx", tag)
-
-    def test_copy_manual(self):
-        self.workflow.copy_previous_user_manual()


### PR DESCRIPTION
Option to copy previous user manual is used when user manual is not changed. It's comfortable since downloading user manual takes a lot of time. 

Fix a bug with the user manual name when downloading it. 

Refactoring paths.