### PR TITLE
Migrate build ps1

### DIFF
--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -1,0 +1,67 @@
+from __future__ import print_function
+import os
+from shutil import copyfile
+from release_ccharp.exceptions import SnpseqReleaseException
+from release_ccharp.snpseq_paths import SnpseqPathActions
+from release_ccharp.apps.common import BinaryVersionUpdater
+from release_ccharp.apps.common import StandardVSConfigXML
+from release_ccharp.apps.common import ApplicationBase
+
+
+class Application(ApplicationBase):
+    """
+    Code that is specific to the Chiasma application
+    It needs snpseq-workflow because the latest and candidate version
+    is fetch through the github provider (in the workflow)
+    """
+    def __init__(self, snpseq_workflow, branch_provider, whatif):
+        super(Application, self).__init__(snpseq_workflow, branch_provider, whatif)
+        self.binary_version_updater = BinaryVersionUpdater(
+            whatif=False, config=self.config, path_properties=self.path_properties,
+            branch_provider=branch_provider, app_paths=self.app_paths)
+
+    def build(self):
+        self.check_build_not_already_run()
+        self.update_binary_version()
+        self.build_solution()
+        self.move_candidates()
+        self.transform_config()
+
+    def update_binary_version(self):
+        self.binary_version_updater.update_binary_version()
+
+    def check_build_not_already_run(self):
+        if os.path.exists(self.app_paths.production_dir) or \
+                os.path.exists(self.app_paths.validation_dir):
+            raise SnpseqReleaseException(
+                ("Production or validation catalog already exists. " 
+                "They need to be removed before continuing"))
+
+    def build_solution(self):
+        self.builder.build_solution()
+
+    def move_candidates(self):
+        self.app_paths.move_candidates()
+
+    def _transform_config(self, directory):
+        config_file_path = os.path.join(directory, self.app_paths.config_file_name)
+        db_name = "GTDB2" if directory == self.app_paths.production_dir else "GTDB2_practice"
+        with self.open_xml(config_file_path) as xml:
+            config = StandardVSConfigXML(xml, "Molmed.Chiasma")
+            config.update("EnforceAppVersion", "True")
+            config.update("DilutePlateAutomaticLabelPrint", "True")
+            config.update("DiluteTubeAutomaticLabelPrint", "True")
+            config.update("DebugMode", "False")
+            config.update("DatabaseName", db_name)
+        lab_config_dir = os.path.join(directory, "Config_lab")
+        path_actions = SnpseqPathActions(whatif=self.whatif, snpseq_path_properties=self.path_properties)
+        path_actions.create_dirs(lab_config_dir)
+        lab_config_file_path = os.path.join(lab_config_dir, self.app_paths.config_file_name)
+        copyfile(config_file_path, lab_config_file_path)
+        with self.open_xml(lab_config_file_path, backup_origfile=False) as xml:
+            config = StandardVSConfigXML(xml, "Molmed.Chiasma")
+            config.update("ApplicationMode", "LAB")
+
+    def transform_config(self):
+        self._transform_config(self.app_paths.production_dir)
+        self._transform_config(self.app_paths.validation_dir)

--- a/release_ccharp/apps/common.py
+++ b/release_ccharp/apps/common.py
@@ -1,0 +1,167 @@
+from __future__ import print_function
+import os
+import re
+import abc
+import xml.etree.ElementTree as ET
+from shutil import copyfile
+from subprocess import call
+from shutil import copytree
+from contextlib import contextmanager
+from release_ccharp.utils import single
+from release_ccharp.utils import lazyprop
+from release_ccharp.exceptions import SnpseqReleaseException
+
+
+class ApplicationBase(object):
+    def __init__(self, snpseq_workflow, branch_provider, whatif):
+        self.snpseq_workflow = snpseq_workflow
+        self.config = snpseq_workflow.config
+        self.path_properties = snpseq_workflow.paths
+        self.branch_provider = branch_provider
+        self.whatif = whatif
+        self.app_paths = AppPaths(self.config, self.path_properties)
+        self.builder = AppBuilder(self.app_paths)
+
+    @contextmanager
+    def open_xml(self, path, backup_origfile=True):
+        orig_file_path = "{}.orig".format(path)
+        self.log("Updating xml file: {}".format(path))
+        if backup_origfile and not os.path.exists(orig_file_path):
+            self.log("Saving backup of original file: {}".format(orig_file_path))
+            copyfile(path, orig_file_path)
+        tree = ET.parse(path)
+        yield tree.getroot()
+        tree.write(path)
+
+    def log(self, msg):
+        if self.whatif:
+            print(msg)
+
+    @abc.abstractmethod
+    def build(self):
+        pass
+
+
+class StandardVSConfigXML:
+    def __init__(self, tree_root, app_namespace):
+        settings_node_name = "{}.Properties.Settings".format(app_namespace)
+        self.setting_list = \
+            tree_root.find('applicationSettings').find(settings_node_name).findall('setting')
+
+    def update(self, key, value):
+        node = single([n for n in self.setting_list if n.get('name') == key])
+        node.find('value').text = value
+
+
+class AppBuilder:
+    def __init__(self, app_paths):
+        self.app_paths = app_paths
+
+    def find_solution_file(self):
+        download_dir = self.app_paths.download_dir
+        lst = [o for o in os.listdir(download_dir) if os.path.isfile(os.path.join(download_dir, o))]
+        for file in lst:
+            if file.endswith(".sln"):
+                return file
+        raise SnpseqReleaseException("The solution file could not be found, directory {}".format(download_dir))
+
+    def build_solution(self):
+        build_path = r'C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe'
+        solution_file = self.find_solution_file()
+        print("build on solution file: {}".format(solution_file))
+        target = os.path.join(self.app_paths.download_dir, solution_file)
+        cmd = [build_path, target,
+               r'/p:WarningLevel=0',
+               r'/verbosity:minimal',
+               r'/p:Configuration=Release']
+        call(cmd)
+
+
+class AppPaths:
+    def __init__(self, config, path_properties):
+        self.config = config
+        self.path_properties = path_properties
+
+    def find_download_directory_name(self):
+        candidate_dir = self.path_properties.current_candidate_dir
+        pattern = "{}-{}".format(self.config["owner"], self.config["git_repo_name"])
+        dir_lst = [o for o in os.listdir(candidate_dir) if os.path.isdir(os.path.join(candidate_dir, o))]
+        for d in dir_lst:
+            if pattern in d:
+                return d
+        return None
+
+    @lazyprop
+    def download_dir(self):
+        return os.path.join(self.path_properties.current_candidate_dir,
+                            self.find_download_directory_name())
+
+    @lazyprop
+    def validation_dir(self):
+        cand_dir = self.path_properties.current_candidate_dir
+        return os.path.join(cand_dir, "validation")
+
+    @lazyprop
+    def production_dir(self):
+        cand_dir = self.path_properties.current_candidate_dir
+        return os.path.join(cand_dir, "production")
+
+    @lazyprop
+    def config_file_name(self):
+        return "{}.exe.config".format(self.config["git_repo_name"])
+
+    def move_candidates(self):
+        release_subdir = os.path.join(self.config["git_repo_name"], r'bin\release')
+        release_dir = os.path.join(self.download_dir, release_subdir)
+        copytree(release_dir, self.validation_dir)
+        copytree(release_dir, self.production_dir)
+
+
+class BinaryVersionUpdater:
+    def __init__(self, whatif, config, path_properties, branch_provider, app_paths):
+        self.config = config
+        self.whatif = whatif
+        self.path_properties = path_properties
+        self.branch_provider = branch_provider
+        self.app_paths = app_paths
+
+    @lazyprop
+    def assembly_file_path(self):
+        assembly_subpath = os.path.join(self.config["git_repo_name"], r'properties\assemblyinfo.cs')
+        assembly_file_path = os.path.join(
+            self.app_paths.download_dir, assembly_subpath)
+        if not os.path.exists(assembly_file_path):
+            raise SnpseqReleaseException(
+                "The assembly info file could not be found {}".format(assembly_file_path))
+        return assembly_file_path
+
+    def _save_assembly_backup(self):
+        orig_file_path = "{}.orig".format(self.assembly_file_path)
+        if not os.path.exists(orig_file_path):
+            print("Saving backup of original file: {}".format(orig_file_path))
+            copyfile(self.assembly_file_path, orig_file_path)
+
+    def get_assembly_replace_strings(self, content, new_version):
+        match = re.search("assembly: AssemblyVersion\(\".+\"\)", content)
+        if match is None:
+            raise SnpseqReleaseException("AssemblyVersion could not be found in AssemblyInfo file")
+        replace_string = match.group(0)
+        new_string = "assembly: AssemblyVersion(\"{}\")".format(new_version)
+        return replace_string, new_string
+
+    def update_binary_version(self):
+        print("Updating assembly info file...")
+        self._save_assembly_backup()
+        with open(self.assembly_file_path, 'r') as f:
+            content = f.read()
+        version = self.branch_provider.candidate_version
+        current, new = self.get_assembly_replace_strings(content, version)
+
+        print("Replacing ")
+        print(current)
+        print("with")
+        print(new)
+        updated = content.replace(current, new)
+        if not self.whatif:
+            with open(self.assembly_file_path, 'w') as f:
+                f.write(updated)

--- a/release_ccharp/apps/dev_environment.py
+++ b/release_ccharp/apps/dev_environment.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import os
+from release_ccharp.snpseq_paths import SnpseqPathProperties
+from release_ccharp.snpseq_paths import SnpseqPathActions
+from release_ccharp.snpseq_workflow import SnpseqWorkflow
+
+
+class TestEnvironmentProvider:
+    def __init__(self):
+        self.candidate_folder = "new-candidate"
+
+    def generate(self, config):
+        # Prepare
+        path_properites = SnpseqPathProperties(config, config["git_repo_name"])
+        path_actions = SnpseqPathActions(whatif=False, snpseq_path_properties=path_properites)
+        wf = SnpseqWorkflow(whatif=False, repo=config["git_repo_name"])
+        wf.config = config
+        branch = "master"
+        cand_path = os.path.join(path_properites.candidate_root_path, self.candidate_folder)
+
+        # Actions
+        path_actions.generate_folder_tree()
+        path_actions.create_dirs(cand_path)
+        wf.workflow.provider.download_archive(branch, cand_path)

--- a/release_ccharp/apps/testing_repo.py
+++ b/release_ccharp/apps/testing_repo.py
@@ -1,0 +1,7 @@
+from __future__ import print_function
+from release_ccharp.apps.common import ApplicationBase
+
+
+class Application(ApplicationBase):
+    def build(self):
+        print("hello")

--- a/release_ccharp/branches.py
+++ b/release_ccharp/branches.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+from release_ccharp.utils import lazyprop
+from release_ccharp.exceptions import SnpseqReleaseException
+from release_tools.workflow import Conventions
+
+
+class BranchProvider:
+    """
+    A wrapper of the release-tools Workflow class
+    providing convenience methods
+    """
+    def __init__(self, workflow):
+        self.workflow = workflow
+
+    @lazyprop
+    def latest_version(self):
+        return self.workflow.get_latest_version()
+
+    @lazyprop
+    def candidate_branch(self):
+        queue = self.workflow.get_queue()
+        if len(queue) == 0:
+            raise SnpseqReleaseException("There is no new candidate branch")
+        return queue[0]
+
+    @lazyprop
+    def candidate_version(self):
+        tag = Conventions.get_tag_from_branch(self.candidate_branch)
+        return Conventions.get_version_from_tag(tag)
+

--- a/release_ccharp/cli.py
+++ b/release_ccharp/cli.py
@@ -3,6 +3,7 @@ from release_ccharp.snpseq_workflow import SnpseqWorkflow
 from release_ccharp.snpseq_paths import SnpseqPathProperties
 from release_ccharp.snpseq_paths import SnpseqPathActions
 from release_ccharp.config import Config
+from release_ccharp.apps.common import ApplicationFactory
 
 
 @click.group()
@@ -36,6 +37,14 @@ def download(ctx, repo):
     workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo)
     workflow.download()
 
+
+@cli.command("build")
+@click.argument("repo")
+@click.pass_context
+def build(ctx, repo):
+    factory = ApplicationFactory()
+    instance = factory.get_instance(whatif=ctx.obj['whatif'], repo=repo)
+    instance.build()
 
 @cli.command("accept")
 @click.argument("repo")

--- a/release_ccharp/snpseq_workflow.py
+++ b/release_ccharp/snpseq_workflow.py
@@ -1,21 +1,20 @@
+from subprocess import call
+from shutil import copyfile
+import yaml
+import os
 from release_tools.workflow import Workflow
 from release_tools.workflow import Conventions
 from release_tools.github import GithubProvider
 from release_ccharp.snpseq_paths import SnpseqPathProperties
 from release_ccharp.exceptions import SnpseqReleaseException
-from subprocess import call
-from PyPDF2 import PdfFileWriter
-from PyPDF2 import PdfFileReader
-from reportlab.pdfgen import canvas
-from reportlab.lib.pagesizes import A4
-from shutil import copyfile
-import StringIO
-import yaml
-import os
 from release_ccharp.config import Config
+from release_ccharp.branches import BranchProvider
 
 
 class SnpseqWorkflow:
+    """
+    Initializes a release-tools workflow to act on the github provider
+    """
     def __init__(self, whatif, repo):
         conf = Config()
         self.config = conf.open_config(repo)
@@ -23,7 +22,7 @@ class SnpseqWorkflow:
         self.repo = repo
         self.paths = SnpseqPathProperties(self.config, self.repo)
         self.workflow = self._create_workflow()
-        self.paths.workflow = self.workflow
+        self.paths.branch_provider = BranchProvider(self.workflow)
 
     def _open_github_provider_config(self, config_file):
         with open(config_file) as f:

--- a/release_ccharp/utils.py
+++ b/release_ccharp/utils.py
@@ -1,0 +1,9 @@
+# http://stackoverflow.com/a/3013910/282024
+def lazyprop(fn):
+    attr_name = '_lazy_' + fn.__name__
+    @property
+    def _lazyprop(self):
+        if not hasattr(self, attr_name):
+            setattr(self, attr_name, fn(self))
+        return getattr(self, attr_name)
+    return _lazyprop

--- a/release_ccharp/utils.py
+++ b/release_ccharp/utils.py
@@ -1,3 +1,5 @@
+import types
+
 # http://stackoverflow.com/a/3013910/282024
 def lazyprop(fn):
     attr_name = '_lazy_' + fn.__name__
@@ -7,3 +9,28 @@ def lazyprop(fn):
             setattr(self, attr_name, fn(self))
         return getattr(self, attr_name)
     return _lazyprop
+
+def single(seq):
+    """Returns the first element in a list, throwing an exception if there is an unexpected number of items"""
+    if isinstance(seq, types.GeneratorType):
+        seq = list(seq)
+    if len(seq) != 1:
+        raise UnexpectedLengthError(
+            "Unexpected number of items in the list ({})".format(len(seq)))
+    return seq[0]
+
+
+def single_or_default(seq):
+    """Returns the first element in a list or None if the list is empty, raising an exception if
+    there are more than one elements in the list"""
+    if len(seq) > 1:
+        raise UnexpectedLengthError(
+            "Expecting at most one item in the list. Got ({}).".format(len(seq)))
+    elif len(seq) == 0:
+        return None
+    else:
+        return seq[0]
+
+
+class UnexpectedLengthError(ValueError):
+    pass

--- a/tests/application_factory_tests.py
+++ b/tests/application_factory_tests.py
@@ -1,0 +1,16 @@
+from __future__ import print_function
+import unittest
+from release_ccharp.apps.common import ApplicationFactory
+
+
+class ApplicationFactoryTests(unittest.TestCase):
+    def setUp(self):
+        self.factory = ApplicationFactory()
+
+    def test_initiate_chiasma(self):
+        instance = self.factory.get_instance(False, "chiasma")
+        self.assertTrue(getattr(instance, "build"))
+
+    def test_initiate_testing_repo(self):
+        instance = self.factory.get_instance(False, "testing-repo")
+        self.assertTrue(getattr(instance, "build"))

--- a/tests/chiasma_build_tests.py
+++ b/tests/chiasma_build_tests.py
@@ -1,0 +1,90 @@
+from __future__ import print_function
+import unittest
+from release_ccharp.apps.chiasma import Application
+from release_ccharp.snpseq_workflow import SnpseqWorkflow
+from release_ccharp.apps.dev_environment import TestEnvironmentProvider
+
+
+class ChiasmaBuildTests(unittest.TestCase):
+    def setUp(self):
+        config = {
+            "root_path": r'c:\tmp',
+            "git_repo_name": "chiasma",
+            "confluence_space_key": "CHI",
+            "owner": "GitEdvard"
+        }
+        branch_provider = FakeBranchProvider()
+        wf = SnpseqWorkflow(whatif=False, repo="chiasma")
+        wf.config = config
+        wf.paths.config = config
+        wf.paths.branch_provider = branch_provider
+        self.chiasma = Application(wf, branch_provider, whatif=False)
+
+    @unittest.skip("Requires folder structure setup")
+    def test__check_build_not_already_run__with_validation_folder_already_existing__exception(self):
+        self.chiasma.check_build_not_already_run()
+
+    def test__get_version(self):
+        version = self.chiasma.branch_provider.candidate_version
+        self.assertEqual("1.0.0", version)
+
+    @unittest.skip("Writes to harddisk")
+    def test__generate_environment(self):
+        config = {
+            "root_path": r'c:\tmp\test_generate',
+            "git_repo_name": "testing-repo",
+            "confluence_space_key": "CHI",
+            "owner": "GitEdvard"
+        }
+        provider = TestEnvironmentProvider()
+        provider.generate(config)
+        self.assertEqual(1,2)
+
+    def test__repo_root(self):
+        root_path = self.chiasma.path_properties._repo_root
+        self.assertEqual(r'c:\tmp\chiasma', root_path)
+
+    @unittest.skip("The name contains sha and changes")
+    def test_find_download_directory(self):
+        name = self.chiasma.app_paths.find_download_directory_name()
+        self.assertEqual("", name)
+
+    @unittest.skip("")
+    def test__update_binary_version(self):
+        self.chiasma.update_binary_version()
+        self.assertEqual(1,2)
+
+    def test_replace_assebly_version(self):
+        s = """line1
+[assembly: AssemblyVersion("1.6.*")]
+line 3"""
+        (current, new) = self.chiasma.binary_version_updater.get_assembly_replace_strings(s, "1.0.0")
+        self.assertEqual("assembly: AssemblyVersion(\"1.6.*\")", current)
+        self.assertEqual("assembly: AssemblyVersion(\"1.0.0\")", new)
+
+    @unittest.skip("Takes time, and requires code tree downloaded in folder structure")
+    def test_build_solution(self):
+        self.chiasma.build_solution()
+        self.assertEqual(1,2)
+
+    @unittest.skip("Fails if validation or production directory already exists")
+    def test_move_candidates(self):
+        self.chiasma.move_candidates()
+        self.assertEqual(1,2)
+
+    @unittest.skip("")
+    def test_transform_config(self):
+        self.chiasma.transform_config()
+        self.assertEqual(1,2)
+
+    @unittest.skip("")
+    def test_build(self):
+        self.chiasma.build()
+        self.assertEqual(1,2)
+
+
+class FakeBranchProvider:
+    def __init__(self):
+        self.candidate_version = "1.0.0"
+        self.latest_version = "latest-version"
+        self.candidate_branch = "new-candidate"

--- a/tests/path_tests.py
+++ b/tests/path_tests.py
@@ -31,6 +31,6 @@ class PathTests(unittest.TestCase):
         self.assertEqual("xxx", root_path)
 
     def test_generate_paths(self):
-        generator = SnpseqPathActions(self.path_properties)
+        generator = SnpseqPathActions(False, self.path_properties)
         generator.generate_folder_tree()
         self.assertEqual(1,2)


### PR DESCRIPTION
Incorporate functionality from build.ps1 into the release-ccharp framework. The build method includes the following steps:
* Update the AssemblyInfo file with the current version
* Build solution
* Move candidate build to the production and validation folder
* Update config files
* Create config files for lab-usage

Code that could be re-used by other applications are separated into the common module.