### PR TITLE
Chi 700 implement deploy validation

### DIFF
--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -9,7 +9,7 @@ class Application(ApplicationBase):
     """
     Code that is specific to the Chiasma application
     It needs snpseq-workflow because the latest and candidate version
-    is fetch through the github provider (in the workflow)
+    is fetched through the github provider (in the workflow)
     """
     def __init__(self, snpseq_workflow, branch_provider, os_service, windows_commands, whatif):
         super(Application, self).__init__(snpseq_workflow, branch_provider, os_service,

--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -10,8 +10,9 @@ class Application(ApplicationBase):
     It needs snpseq-workflow because the latest and candidate version
     is fetch through the github provider (in the workflow)
     """
-    def __init__(self, snpseq_workflow, branch_provider, os_service, whatif):
-        super(Application, self).__init__(snpseq_workflow, branch_provider, os_service, whatif)
+    def __init__(self, snpseq_workflow, branch_provider, os_service, windows_commands, whatif):
+        super(Application, self).__init__(snpseq_workflow, branch_provider, os_service,
+                                          windows_commands, whatif)
         self.binary_version_updater = BinaryVersionUpdater(
             whatif=False, config=self.config, path_properties=self.path_properties,
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)

--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -1,11 +1,7 @@
 from __future__ import print_function
-import os
-from shutil import copyfile
-from release_ccharp.exceptions import SnpseqReleaseException
-from release_ccharp.snpseq_paths import SnpseqPathActions
 from release_ccharp.apps.common import BinaryVersionUpdater
-from release_ccharp.apps.common import StandardVSConfigXML
 from release_ccharp.apps.common import ApplicationBase
+from release_ccharp.apps.chiasma_scripts.builder import ChiasmaBuilder
 
 
 class Application(ApplicationBase):
@@ -19,51 +15,7 @@ class Application(ApplicationBase):
         self.binary_version_updater = BinaryVersionUpdater(
             whatif=False, config=self.config, path_properties=self.path_properties,
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
+        self.chiasma_builder = ChiasmaBuilder(self)
 
     def build(self):
-        self.check_build_not_already_run()
-        self.update_binary_version()
-        self.build_solution()
-        self.move_candidates()
-        self.transform_config()
-
-    def update_binary_version(self):
-        self.binary_version_updater.update_binary_version()
-
-    def check_build_not_already_run(self):
-        if os.path.exists(self.app_paths.production_dir) or \
-                os.path.exists(self.app_paths.validation_dir):
-            raise SnpseqReleaseException(
-                ("Production or validation catalog already exists. " 
-                "They need to be removed before continuing"))
-
-    def build_solution(self):
-        self.builder.build_solution()
-
-    def move_candidates(self):
-        self.app_paths.move_candidates()
-
-    def _transform_config(self, directory):
-        config_file_path = os.path.join(directory, self.app_paths.config_file_name)
-        db_name = "GTDB2" if directory == self.app_paths.production_dir else "GTDB2_practice"
-        with self.open_xml(config_file_path) as xml:
-            config = StandardVSConfigXML(xml, "Molmed.Chiasma")
-            config.update("EnforceAppVersion", "True")
-            config.update("DilutePlateAutomaticLabelPrint", "True")
-            config.update("DiluteTubeAutomaticLabelPrint", "True")
-            config.update("DebugMode", "False")
-            config.update("DatabaseName", db_name)
-        lab_config_dir = os.path.join(directory, "Config_lab")
-        path_actions = SnpseqPathActions(whatif=self.whatif,
-                                         snpseq_path_properties=self.path_properties,
-                                         os_service=self.os_service)
-        path_actions.create_dirs(lab_config_dir)
-        lab_config_file_path = os.path.join(lab_config_dir, self.app_paths.config_file_name)
-        self.os_service.copyfile(config_file_path, lab_config_file_path)
-        with self.open_xml(lab_config_file_path, backup_origfile=False) as xml:
-            config = StandardVSConfigXML(xml, "Molmed.Chiasma")
-            config.update("ApplicationMode", "LAB")
-
-    def transform_config(self):
-        self._transform_config(self.app_paths.production_dir)
-        self._transform_config(self.app_paths.validation_dir)
+        self.chiasma_builder.run()

--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from release_ccharp.apps.common import BinaryVersionUpdater
 from release_ccharp.apps.common import ApplicationBase
 from release_ccharp.apps.chiasma_scripts.builder import ChiasmaBuilder
+from release_ccharp.apps.chiasma_scripts.validation_deployer import ChiasmaValidationDeployer
 
 
 class Application(ApplicationBase):
@@ -17,6 +18,10 @@ class Application(ApplicationBase):
             whatif=False, config=self.config, path_properties=self.path_properties,
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         self.chiasma_builder = ChiasmaBuilder(self)
+        self.validation_deployer = ChiasmaValidationDeployer(self)
 
     def build(self):
         self.chiasma_builder.run()
+
+    def deploy_validation(self):
+        self.validation_deployer.run()

--- a/release_ccharp/apps/chiasma_scripts/builder.py
+++ b/release_ccharp/apps/chiasma_scripts/builder.py
@@ -2,9 +2,8 @@ from __future__ import print_function
 import os
 from release_ccharp.exceptions import SnpseqReleaseException
 from release_ccharp.snpseq_paths import SnpseqPathActions
-from release_ccharp.apps.common import BinaryVersionUpdater
 from release_ccharp.apps.common import StandardVSConfigXML
-from release_ccharp.apps.common import ApplicationBase
+from release_ccharp.utils import create_dirs
 
 
 class ChiasmaBuilder:
@@ -55,10 +54,8 @@ class ChiasmaBuilder:
             config.update("DebugMode", "False")
             config.update("DatabaseName", db_name)
         lab_config_dir = os.path.join(directory, "Config_lab")
-        path_actions = SnpseqPathActions(whatif=self.chiasma.whatif,
-                                         snpseq_path_properties=self.chiasma.path_properties,
-                                         os_service=self.chiasma.os_service)
-        path_actions.create_dirs(lab_config_dir)
+        create_dirs(self.chiasma.os_service, lab_config_dir, self.chiasma.whatif,
+                    self.chiasma.whatif)
         lab_config_file_path = os.path.join(lab_config_dir, self.chiasma.app_paths.config_file_name)
         self.chiasma.os_service.copyfile(config_file_path, lab_config_file_path)
         with self.chiasma.open_xml(lab_config_file_path, backup_origfile=False) as xml:

--- a/release_ccharp/apps/chiasma_scripts/builder.py
+++ b/release_ccharp/apps/chiasma_scripts/builder.py
@@ -29,7 +29,17 @@ class ChiasmaBuilder:
                 "They need to be removed before continuing"))
 
     def build_solution(self):
-        self.chiasma.windows_commands.build_solution()
+        solution_file = self._find_solution_file()
+        solution_file_path = os.path.join(self.chiasma.app_paths.download_dir, solution_file)
+        self.chiasma.windows_commands.build_solution(solution_file_path)
+
+    def _find_solution_file(self):
+        download_dir = self.chiasma.app_paths.download_dir
+        lst = [o for o in os.listdir(download_dir) if os.path.isfile(os.path.join(download_dir, o))]
+        for file in lst:
+            if file.endswith(".sln"):
+                return file
+        raise SnpseqReleaseException("The solution file could not be found, directory {}".format(download_dir))
 
     def move_candidates(self):
         self.chiasma.app_paths.move_candidates()

--- a/release_ccharp/apps/chiasma_scripts/builder.py
+++ b/release_ccharp/apps/chiasma_scripts/builder.py
@@ -1,0 +1,60 @@
+from __future__ import print_function
+import os
+from release_ccharp.exceptions import SnpseqReleaseException
+from release_ccharp.snpseq_paths import SnpseqPathActions
+from release_ccharp.apps.common import BinaryVersionUpdater
+from release_ccharp.apps.common import StandardVSConfigXML
+from release_ccharp.apps.common import ApplicationBase
+
+
+class ChiasmaBuilder:
+    def __init__(self, chiasma):
+        self.chiasma = chiasma
+
+    def run(self):
+        self.check_build_not_already_run()
+        self.update_binary_version()
+        self.build_solution()
+        self.move_candidates()
+        self.transform_config()
+
+    def update_binary_version(self):
+        self.chiasma.binary_version_updater.update_binary_version()
+
+    def check_build_not_already_run(self):
+        if os.path.exists(self.chiasma.app_paths.production_dir) or \
+                os.path.exists(self.chiasma.app_paths.validation_dir):
+            raise SnpseqReleaseException(
+                ("Production or validation catalog already exists. " 
+                "They need to be removed before continuing"))
+
+    def build_solution(self):
+        self.chiasma.compile_runner.build_solution()
+
+    def move_candidates(self):
+        self.chiasma.app_paths.move_candidates()
+
+    def _transform_config(self, directory):
+        config_file_path = os.path.join(directory, self.chiasma.app_paths.config_file_name)
+        db_name = "GTDB2" if directory == self.chiasma.app_paths.production_dir else "GTDB2_practice"
+        with self.chiasma.open_xml(config_file_path) as xml:
+            config = StandardVSConfigXML(xml, "Molmed.Chiasma")
+            config.update("EnforceAppVersion", "True")
+            config.update("DilutePlateAutomaticLabelPrint", "True")
+            config.update("DiluteTubeAutomaticLabelPrint", "True")
+            config.update("DebugMode", "False")
+            config.update("DatabaseName", db_name)
+        lab_config_dir = os.path.join(directory, "Config_lab")
+        path_actions = SnpseqPathActions(whatif=self.chiasma.whatif,
+                                         snpseq_path_properties=self.chiasma.path_properties,
+                                         os_service=self.chiasma.os_service)
+        path_actions.create_dirs(lab_config_dir)
+        lab_config_file_path = os.path.join(lab_config_dir, self.chiasma.app_paths.config_file_name)
+        self.chiasma.os_service.copyfile(config_file_path, lab_config_file_path)
+        with self.chiasma.open_xml(lab_config_file_path, backup_origfile=False) as xml:
+            config = StandardVSConfigXML(xml, "Molmed.Chiasma")
+            config.update("ApplicationMode", "LAB")
+
+    def transform_config(self):
+        self._transform_config(self.chiasma.app_paths.production_dir)
+        self._transform_config(self.chiasma.app_paths.validation_dir)

--- a/release_ccharp/apps/chiasma_scripts/builder.py
+++ b/release_ccharp/apps/chiasma_scripts/builder.py
@@ -29,7 +29,7 @@ class ChiasmaBuilder:
                 "They need to be removed before continuing"))
 
     def build_solution(self):
-        self.chiasma.compile_runner.build_solution()
+        self.chiasma.windows_commands.build_solution()
 
     def move_candidates(self):
         self.chiasma.app_paths.move_candidates()

--- a/release_ccharp/apps/chiasma_scripts/validation_deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/validation_deployer.py
@@ -15,3 +15,6 @@ class ChiasmaValidationDeployer:
         save_path = os.path.join(self.chiasma.path_properties.user_validation_latest, 'Chiasma.lnk')
         self.chiasma.windows_commands.create_shortcut(save_path, shortcut_target)
 
+    def extract_shortcut_target(self, shortcut_path):
+        return self.chiasma.windows_commands.extract_shortcut_target(shortcut_path)
+

--- a/release_ccharp/apps/chiasma_scripts/validation_deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/validation_deployer.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+from release_ccharp.utils import copytree_preserve_existing
 
 
 class ChiasmaValidationDeployer:
@@ -12,9 +13,14 @@ class ChiasmaValidationDeployer:
 
     def create_shortcut(self):
         shortcut_target = os.path.join(self.chiasma.app_paths.validation_dir, 'Chiasma.exe')
-        save_path = os.path.join(self.chiasma.path_properties.user_validation_latest, 'Chiasma.lnk')
+        save_path = os.path.join(self.chiasma.path_properties.user_validations_latest, 'Chiasma.lnk')
         self.chiasma.windows_commands.create_shortcut(save_path, shortcut_target)
 
     def extract_shortcut_target(self, shortcut_path):
         return self.chiasma.windows_commands.extract_shortcut_target(shortcut_path)
+
+    def copy_validation_files(self):
+        source_dir = self.chiasma.path_properties.user_validations_next_dir
+        target_dir = self.chiasma.path_properties.latest_validation_files
+        copytree_preserve_existing(self.os_service, source_dir, target_dir)
 

--- a/release_ccharp/apps/chiasma_scripts/validation_deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/validation_deployer.py
@@ -45,7 +45,7 @@ class ChiasmaValidationDeployer:
         In case of going back to an interrupted validation (for a hotfix during the testperiod)
         :return:
         """
-        src = self.chiasma.path_properties.validation_archive_dir
+        src = self.chiasma.path_properties.archive_dir_validation_files
         dst = self.chiasma.path_properties.latest_validation_files
         copytree_preserve_existing(self.os_service, src, dst)
         delete_directory_contents(self.os_service, src)
@@ -75,6 +75,6 @@ class ChiasmaValidationDeployer:
     def copy_validation_files(self):
         if not self._is_candidate_in_latest:
             self._move_to_archive()
-        if self.os_service.exists(self.chiasma.path_properties.validation_archive_dir):
+        if self.os_service.exists(self.chiasma.path_properties.archive_dir_validation_files):
             self._back_move_from_archive()
         self._copy_to_latest()

--- a/release_ccharp/apps/chiasma_scripts/validation_deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/validation_deployer.py
@@ -1,0 +1,16 @@
+from __future__ import print_function
+import os
+
+
+class ChiasmaValidationDeployer:
+    def __init__(self, chiasma):
+        self.chiasma = chiasma
+        self.os_service = chiasma.os_service
+
+    def run(self):
+        pass
+
+    def create_shortcut(self):
+        source = os.path.join(self.chiasma.app_paths.validation_dir, 'Chiasma.exe')
+        dest = os.path.join(self.chiasma.path_properties.user_validation_latest, 'Chiasma.lnk')
+

--- a/release_ccharp/apps/chiasma_scripts/validation_deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/validation_deployer.py
@@ -11,6 +11,7 @@ class ChiasmaValidationDeployer:
         pass
 
     def create_shortcut(self):
-        source = os.path.join(self.chiasma.app_paths.validation_dir, 'Chiasma.exe')
-        dest = os.path.join(self.chiasma.path_properties.user_validation_latest, 'Chiasma.lnk')
+        shortcut_target = os.path.join(self.chiasma.app_paths.validation_dir, 'Chiasma.exe')
+        save_path = os.path.join(self.chiasma.path_properties.user_validation_latest, 'Chiasma.lnk')
+        self.chiasma.windows_commands.create_shortcut(save_path, shortcut_target)
 

--- a/release_ccharp/apps/chiasma_scripts/validation_deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/validation_deployer.py
@@ -1,26 +1,80 @@
 from __future__ import print_function
 import os
 from release_ccharp.utils import copytree_preserve_existing
+from release_ccharp.utils import delete_directory_contents
+from release_ccharp.utils import lazyprop
+from release_ccharp.snpseq_paths import SnpseqPathActions
 
 
 class ChiasmaValidationDeployer:
     def __init__(self, chiasma):
         self.chiasma = chiasma
         self.os_service = chiasma.os_service
+        self.path_actions = SnpseqPathActions(
+            whatif=False, snpseq_path_properties=self.chiasma.path_properties,
+            os_service=self.os_service)
 
     def run(self):
-        pass
+        self.copy_validation_files()
+        self.create_shortcut()
+
+    @lazyprop
+    def shortcut_path(self):
+        return os.path.join(self.chiasma.path_properties.user_validations_latest, 'Chiasma.lnk')
 
     def create_shortcut(self):
         shortcut_target = os.path.join(self.chiasma.app_paths.validation_dir, 'Chiasma.exe')
-        save_path = os.path.join(self.chiasma.path_properties.user_validations_latest, 'Chiasma.lnk')
-        self.chiasma.windows_commands.create_shortcut(save_path, shortcut_target)
+        self.chiasma.windows_commands.create_shortcut(self.shortcut_path, shortcut_target)
 
     def extract_shortcut_target(self, shortcut_path):
         return self.chiasma.windows_commands.extract_shortcut_target(shortcut_path)
 
-    def copy_validation_files(self):
-        source_dir = self.chiasma.path_properties.user_validations_next_dir
+    def _move_to_archive(self):
+        """
+        If interupting an ongoing test for a hotfix, move existing files to archive
+        Archive catalog is fetched from shortcut in latest, not the candidate branch
+        :return:
+        """
+        validation_dir = self.chiasma.path_properties.user_validations_latest
+        target_dir = os.path.join(self.chiasma.path_properties.all_versions, self._version_from_shortcut)
+        copytree_preserve_existing(self.os_service, validation_dir, target_dir)
+        delete_directory_contents(self.os_service, validation_dir)
+
+    def _back_move_from_archive(self):
+        """
+        In case of going back to an interrupted validation (for a hotfix during the testperiod)
+        :return:
+        """
+        src = self.chiasma.path_properties.validation_archive_dir
+        dst = self.chiasma.path_properties.latest_validation_files
+        copytree_preserve_existing(self.os_service, src, dst)
+        delete_directory_contents(self.os_service, src)
+
+
+    def _copy_to_latest(self):
+        source_dir = self.chiasma.path_properties.next_validation_files
         target_dir = self.chiasma.path_properties.latest_validation_files
         copytree_preserve_existing(self.os_service, source_dir, target_dir)
 
+    @property
+    def _version_from_shortcut(self):
+        shortcut_target = self.extract_shortcut_target(self.shortcut_path)
+        return self._extract_version_from_path(shortcut_target)
+
+    @property
+    def _is_candidate_in_latest(self):
+        version_to_validate = self.chiasma.branch_provider.candidate_version
+        if self.os_service.exists(self.shortcut_path):
+            return self._version_from_shortcut == version_to_validate
+        else:
+            return True
+
+    def _extract_version_from_path(self, path):
+        return self.path_actions.find_version_from_candidate_path(path)
+
+    def copy_validation_files(self):
+        if not self._is_candidate_in_latest:
+            self._move_to_archive()
+        if self.os_service.exists(self.chiasma.path_properties.validation_archive_dir):
+            self._back_move_from_archive()
+        self._copy_to_latest()

--- a/release_ccharp/apps/common.py
+++ b/release_ccharp/apps/common.py
@@ -75,6 +75,10 @@ class WindowsCommands:
         shortcut.TargetPath = target_path
         shortcut.save()
 
+    def extract_shortcut_target(self, shortcut_path):
+        shell = Dispatch('WScript.Shell')
+        return shell.CreateShortCut(shortcut_path).TargetPath
+
 
 class AppPaths:
     """

--- a/release_ccharp/apps/common.py
+++ b/release_ccharp/apps/common.py
@@ -82,10 +82,10 @@ class WindowsCommands:
 
 class AppPaths:
     """
-    Handles directories which is located under a specific candidate
-    Also include path actions
+    Handles directories which is located under a specific candidate (properties and path actions).
+    This directory structure may differ between applications, and some
+    properties and methods may therefore only be applicable to some of the apps.
     """
-    # TODO: move to snpseq_paths?
     def __init__(self, config, path_properties, os_service):
         self.config = config
         self.path_properties = path_properties

--- a/release_ccharp/apps/common.py
+++ b/release_ccharp/apps/common.py
@@ -21,7 +21,7 @@ class ApplicationBase(object):
         self.whatif = whatif
         self.os_service = os_service
         self.app_paths = AppPaths(self.config, self.path_properties, os_service)
-        self.builder = AppBuilder(self.app_paths)
+        self.compile_runner = AppBuilder(self.app_paths)
 
     @contextmanager
     def open_xml(self, path, backup_origfile=True):

--- a/release_ccharp/apps/common.py
+++ b/release_ccharp/apps/common.py
@@ -13,7 +13,7 @@ from release_ccharp.utility.os_service import OsService
 
 
 class ApplicationBase(object):
-    def __init__(self, snpseq_workflow, branch_provider, os_service, whatif):
+    def __init__(self, snpseq_workflow, branch_provider, os_service, windows_commands, whatif):
         self.snpseq_workflow = snpseq_workflow
         self.config = snpseq_workflow.config
         self.path_properties = snpseq_workflow.paths
@@ -21,7 +21,7 @@ class ApplicationBase(object):
         self.whatif = whatif
         self.os_service = os_service
         self.app_paths = AppPaths(self.config, self.path_properties, os_service)
-        self.compile_runner = AppBuilder(self.app_paths)
+        self.windows_commands = windows_commands
 
     @contextmanager
     def open_xml(self, path, backup_origfile=True):
@@ -58,7 +58,7 @@ class StandardVSConfigXML:
         return node.find('value').text
 
 
-class AppBuilder:
+class WindowsCommands:
     def __init__(self, app_paths):
         self.app_paths = app_paths
 
@@ -186,4 +186,4 @@ class ApplicationFactory:
         application = self.import_application(repo)
         wf = SnpseqWorkflow(whatif, repo)
         branch_provider = wf.paths.branch_provider
-        return application(wf, branch_provider, OsService(), whatif)
+        return application(wf, branch_provider, OsService(), WindowsCommands(), whatif)

--- a/release_ccharp/apps/dev_environment.py
+++ b/release_ccharp/apps/dev_environment.py
@@ -18,7 +18,7 @@ class TestEnvironmentProvider:
         wf = SnpseqWorkflow(whatif=False, repo=config["git_repo_name"])
         wf.config = config
         branch = "master"
-        cand_path = os.path.join(path_properites.candidate_root_path, self.candidate_folder)
+        cand_path = os.path.join(path_properites.root_candidates, self.candidate_folder)
 
         # Actions
         path_actions.generate_folder_tree()

--- a/release_ccharp/apps/testing_repo.py
+++ b/release_ccharp/apps/testing_repo.py
@@ -1,7 +1,25 @@
 from __future__ import print_function
+from release_ccharp.apps.common import BinaryVersionUpdater
 from release_ccharp.apps.common import ApplicationBase
+from release_ccharp.apps.chiasma_scripts.builder import ChiasmaBuilder
+from release_ccharp.apps.chiasma_scripts.validation_deployer import ChiasmaValidationDeployer
 
 
 class Application(ApplicationBase):
+    """
+    Uses the chiasma code for testing purposes. Uses a local folder tree
+    """
+    def __init__(self, snpseq_workflow, branch_provider, os_service, windows_commands, whatif):
+        super(Application, self).__init__(snpseq_workflow, branch_provider, os_service,
+                                          windows_commands, whatif)
+        self.binary_version_updater = BinaryVersionUpdater(
+            whatif=False, config=self.config, path_properties=self.path_properties,
+            branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
+        self.chiasma_builder = ChiasmaBuilder(self)
+        self.validation_deployer = ChiasmaValidationDeployer(self)
+
     def build(self):
-        print("hello")
+        self.chiasma_builder.run()
+
+    def deploy_validation(self):
+        self.validation_deployer.run()

--- a/release_ccharp/cli.py
+++ b/release_ccharp/cli.py
@@ -47,6 +47,16 @@ def build(ctx, repo):
     instance = factory.get_instance(whatif=ctx.obj['whatif'], repo=repo)
     instance.build()
 
+
+@cli.command("deploy-validation")
+@click.argument("repo")
+@click.pass_context
+def build(ctx, repo):
+    factory = ApplicationFactory()
+    instance = factory.get_instance(whatif=ctx.obj['whatif'], repo=repo)
+    instance.deploy_validation()
+
+
 @cli.command("accept")
 @click.argument("repo")
 @click.pass_context

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -105,9 +105,39 @@ class SnpseqPathProperties:
         return os.path.join(self.candidate_root_path, self.branch_provider.candidate_branch)
 
     @property
-    def user_validation_latest(self):
-        user_validation_dir = os.path.join(self._repo_root, self.user_validations_subpath)
-        return os.path.join(user_validation_dir, self.user_validations_latest_subpath)
+    def _user_validations(self):
+        return os.path.join(self._repo_root, self.user_validations_subpath)
+
+    @property
+    def _all_versions(self):
+        return os.path.join(self._user_validations, self.user_validations_all_version_subpath)
+
+    @property
+    def user_validations_latest(self):
+        return os.path.join(self._user_validations, self.user_validations_latest_subpath)
+
+    @property
+    def user_validations_next_release(self):
+        return os.path.join(self._all_versions, self.user_validations_next_release_subpath)
+
+    @property
+    def user_validations_next_hotfix(self):
+        return os.path.join(self._all_versions, self.user_validations_next_hotfix_subpath)
+
+    @property
+    def user_validations_next_dir(self):
+        if "release" in self.branch_provider.candidate_branch:
+            return self.user_validations_next_release
+        else:
+            return self.user_validations_next_hotfix
+
+    @property
+    def latest_validation_files(self):
+        return os.path.join(self.user_validations_latest, self.user_validations_validation_files_subpath)
+
+    @property
+    def validation_archive_dir(self):
+        return os.path.join(self._all_versions, self.branch_provider.candidate_version)
 
 
 class SnpseqPathActions:

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -49,7 +49,7 @@ class SnpseqPathProperties:
         return tag
 
     @property
-    def candidate_root_path(self):
+    def root_candidates(self):
         return os.path.join(self._repo_root, self.candidate_subpath)
 
     @property
@@ -86,11 +86,11 @@ class SnpseqPathProperties:
         Find the download catalog for the latest accepted branch
         :return: The path of latest accepted branch
         """
-        subdirs = os.listdir(self.candidate_root_path)
+        subdirs = os.listdir(self.root_candidates)
         subdir_path = None
         for subdir in subdirs:
             if re.match('(release|hotfix)-{}'.format(self.branch_provider.latest_version), subdir):
-                subdir_path = os.path.join(self.candidate_root_path, subdir)
+                subdir_path = os.path.join(self.root_candidates, subdir)
         if subdir_path is None:
             raise SnpseqReleaseException("Could not find the download catalog for latest version")
         return subdir_path
@@ -102,7 +102,7 @@ class SnpseqPathProperties:
         :param workflow: 
         :return: The path of the latest candidate branch
         """
-        return os.path.join(self.candidate_root_path, self.branch_provider.candidate_branch)
+        return os.path.join(self.root_candidates, self.branch_provider.candidate_branch)
 
     @property
     def _user_validations(self):
@@ -154,7 +154,7 @@ class SnpseqPathProperties:
         return os.path.join(self.user_validations_latest, self.user_validations_validation_files_subpath)
 
     @property
-    def validation_archive_dir(self):
+    def archive_dir_validation_files(self):
         archive_version_dir = os.path.join(self.all_versions, str(self.branch_provider.candidate_version))
         return os.path.join(archive_version_dir, self.user_validations_validation_files_subpath)
 

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -109,7 +109,7 @@ class SnpseqPathProperties:
         return os.path.join(self._repo_root, self.user_validations_subpath)
 
     @property
-    def _all_versions(self):
+    def all_versions(self):
         return os.path.join(self._user_validations, self.user_validations_all_version_subpath)
 
     @property
@@ -118,11 +118,11 @@ class SnpseqPathProperties:
 
     @property
     def user_validations_next_release(self):
-        return os.path.join(self._all_versions, self.user_validations_next_release_subpath)
+        return os.path.join(self.all_versions, self.user_validations_next_release_subpath)
 
     @property
     def user_validations_next_hotfix(self):
-        return os.path.join(self._all_versions, self.user_validations_next_hotfix_subpath)
+        return os.path.join(self.all_versions, self.user_validations_next_hotfix_subpath)
 
     @property
     def user_validations_next_dir(self):
@@ -132,12 +132,31 @@ class SnpseqPathProperties:
             return self.user_validations_next_hotfix
 
     @property
+    def next_validation_files(self):
+        """
+        Directory name always 'ValidationFiles', and may be located either in
+        _next_release or _next_hotfix
+        :return:
+        """
+        return os.path.join(self.user_validations_next_dir, self.user_validations_validation_files_subpath)
+
+    @property
+    def next_sql_updates(self):
+        """
+        Directory name always 'SQLUpdates', and may be located either in
+        _next_release or _next_hotfix
+        :return:
+        """
+        return os.path.join(self.user_validations_next_dir, self.user_validations_sql_updates_subpath)
+
+    @property
     def latest_validation_files(self):
         return os.path.join(self.user_validations_latest, self.user_validations_validation_files_subpath)
 
     @property
     def validation_archive_dir(self):
-        return os.path.join(self._all_versions, self.branch_provider.candidate_version)
+        archive_version_dir = os.path.join(self.all_versions, str(self.branch_provider.candidate_version))
+        return os.path.join(archive_version_dir, self.user_validations_validation_files_subpath)
 
 
 class SnpseqPathActions:
@@ -183,3 +202,8 @@ class SnpseqPathActions:
 
     def create_dirs(self, path):
         create_dirs(self.os_service, path, self.whatif, self.whatif)
+
+    def find_version_from_candidate_path(self, candidate_path):
+        res = re.match(r'.*(release|hotfix)-(\d+)\.(\d+)\.(\d+).*', candidate_path)
+        version = '{}.{}.{}'.format(res.group(2), res.group(3), res.group(4))
+        return version

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -103,6 +103,11 @@ class SnpseqPathProperties:
         """
         return os.path.join(self.candidate_root_path, self.branch_provider.candidate_branch)
 
+    @property
+    def user_validation_latest(self):
+        user_validation_dir = os.path.join(self._repo_root, self.user_validations_subpath)
+        return os.path.join(user_validation_dir, self.user_validations_latest_subpath)
+
 
 class SnpseqPathActions:
     def __init__(self, whatif, snpseq_path_properties, os_service):

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -3,6 +3,7 @@ import re
 import yaml
 from release_ccharp.exceptions import SnpseqReleaseException
 from release_tools.workflow import Conventions
+from release_ccharp.utils import create_dirs
 
 
 class SnpseqPathProperties:
@@ -151,9 +152,4 @@ class SnpseqPathActions:
         self.create_dirs(sql_updates_next_release)
 
     def create_dirs(self, path):
-        if not self.os_service.exists(path):
-            print("Create directory: {}".format(path))
-            if not self.whatif:
-                self.os_service.makedirs(path)
-        else:
-            print "Path already exists: {}".format(path)
+        create_dirs(self.os_service, path, self.whatif, self.whatif)

--- a/release_ccharp/snpseq_workflow.py
+++ b/release_ccharp/snpseq_workflow.py
@@ -45,7 +45,7 @@ class SnpseqWorkflow:
         self.workflow.create_hotfix()
 
     def download(self):
-        self.workflow.download_next_in_queue(path=self.paths.candidate_root_path, force=False)
+        self.workflow.download_next_in_queue(path=self.paths.root_candidates, force=False)
 
     def accept(self):
         self.workflow.accept_release_candidate(force=False)

--- a/release_ccharp/utility/os_service.py
+++ b/release_ccharp/utility/os_service.py
@@ -34,3 +34,4 @@ class OsService():
 
     def open(self, path, mode):
         return open(path, mode)
+

--- a/release_ccharp/utility/os_service.py
+++ b/release_ccharp/utility/os_service.py
@@ -1,6 +1,7 @@
 import os
 from shutil import copytree
 from shutil import copyfile
+from shutil import rmtree
 from xml.etree import ElementTree as ET
 
 
@@ -13,6 +14,9 @@ class OsService():
 
     def isdir(self, path):
         return os.path.isdir(path)
+
+    def isfile(self, path):
+        return os.path.isfile(path)
 
     def copytree(self, src, dst):
         copytree(src, dst)
@@ -35,3 +39,8 @@ class OsService():
     def open(self, path, mode):
         return open(path, mode)
 
+    def rmtree(self, path):
+        rmtree(path)
+
+    def remove_file(self, file_path):
+        os.unlink(file_path)

--- a/release_ccharp/utils.py
+++ b/release_ccharp/utils.py
@@ -1,4 +1,5 @@
 import types
+import os
 
 # http://stackoverflow.com/a/3013910/282024
 def lazyprop(fn):
@@ -40,6 +41,28 @@ def create_dirs(os_service, path, whatif=False, log=True):
             os_service.makedirs(path)
     elif log:
         print "Path already exists: {}".format(path)
+
+
+def copytree_preserve_existing(os_service, src, dst):
+    """
+    Copy entire file tree from src to dst. If a file with the same name already exists 
+    in dst, don't overwrite it. If a directory already exists in dst, it's contents will be 
+    preserved, but there might be new files added into it. 
+    :param os_service: From this framework (real or fake)
+    :param src: Source directory. The top directory is not copied, only it's contents
+    :param dst: Destination directory. If it doesn't exists, it will be created.
+    :return: 
+    """
+    oss = os_service
+    if not oss.exists(dst):
+        oss.makedirs(dst)
+    for d in oss.listdir(src):
+        dest_sub_path = os.path.join(dst, d)
+        source_sub_path = os.path.join(src, d)
+        if oss.isdir(source_sub_path):
+            copytree_preserve_existing(oss, source_sub_path, dest_sub_path)
+        elif not oss.exists(dest_sub_path):
+            oss.copyfile(source_sub_path, dest_sub_path)
 
 
 class UnexpectedLengthError(ValueError):

--- a/release_ccharp/utils.py
+++ b/release_ccharp/utils.py
@@ -64,6 +64,20 @@ def copytree_preserve_existing(os_service, src, dst):
         elif not oss.exists(dest_sub_path):
             oss.copyfile(source_sub_path, dest_sub_path)
 
+def delete_directory_contents(os_service, folder):
+    """
+    Removes files and subdirectories in path, but do not remove the top directory
+    :param os_service: From this framework (real or fake)
+    :param folder:
+    :return:
+    """
+    oss = os_service
+    for folder_content in oss.listdir(folder):
+        path = os.path.join(folder, folder_content)
+        if oss.isfile(path):
+            oss.remove_file(path)
+        elif oss.isdir(path):
+            oss.rmtree(path)
 
 class UnexpectedLengthError(ValueError):
     pass

--- a/release_ccharp/utils.py
+++ b/release_ccharp/utils.py
@@ -32,5 +32,15 @@ def single_or_default(seq):
         return seq[0]
 
 
+def create_dirs(os_service, path, whatif=False, log=True):
+    if not os_service.exists(path):
+        if log:
+            print("Create directory: {}".format(path))
+        if not whatif:
+            os_service.makedirs(path)
+    elif log:
+        print "Path already exists: {}".format(path)
+
+
 class UnexpectedLengthError(ValueError):
     pass

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    install_requires=['click', 'pyfakefs'],
+    install_requires=['click', 'pyfakefs', 'pypiwin32'],
 
     # $ pip install -e .[dev,test]
     extras_require={

--- a/tests/integration/chiasma_build_tests.py
+++ b/tests/integration/chiasma_build_tests.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import unittest
 from release_ccharp.apps.chiasma import Application
+from release_ccharp.apps.common import WindowsCommands
 from release_ccharp.snpseq_workflow import SnpseqWorkflow
 from release_ccharp.utility.os_service import OsService
 from release_ccharp.apps.dev_environment import TestEnvironmentProvider
@@ -19,11 +20,12 @@ class ChiasmaBuildTests(unittest.TestCase):
         wf.config = config
         wf.paths.config = config
         wf.paths.branch_provider = branch_provider
-        self.chiasma = Application(wf, branch_provider, OsService(), whatif=False)
+        self.chiasma = Application(wf, branch_provider, OsService(),
+                                   WindowsCommands(), whatif=False)
 
     @unittest.skip("Requires folder structure setup")
     def test__check_build_not_already_run__with_validation_folder_already_existing__exception(self):
-        self.chiasma.check_build_not_already_run()
+        self.chiasma.chiasma_builder.check_build_not_already_run()
 
     @unittest.skip("Writes to harddisk")
     def test__generate_environment(self):
@@ -44,22 +46,22 @@ class ChiasmaBuildTests(unittest.TestCase):
 
     @unittest.skip("")
     def test__update_binary_version(self):
-        self.chiasma.update_binary_version()
+        self.chiasma.chiasma_builder.update_binary_version()
         self.assertEqual(1,2)
 
     @unittest.skip("Takes time, and requires code tree downloaded in folder structure")
     def test_build_solution(self):
-        self.chiasma.build_solution()
+        self.chiasma.chiasma_builder.build_solution()
         self.assertEqual(1,2)
 
     @unittest.skip("Fails if validation or production directory already exists")
     def test_move_candidates(self):
-        self.chiasma.move_candidates()
+        self.chiasma.chiasma_builder.move_candidates()
         self.assertEqual(1,2)
 
     @unittest.skip("")
     def test_transform_config(self):
-        self.chiasma.transform_config()
+        self.chiasma.chiasma_builder.transform_config()
         self.assertEqual(1,2)
 
     @unittest.skip("")

--- a/tests/integration/chiasma_validation_deploy_tests.py
+++ b/tests/integration/chiasma_validation_deploy_tests.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest import skip
+from release_ccharp.snpseq_workflow import SnpseqWorkflow
+from release_ccharp.apps.chiasma import Application
+from release_ccharp.apps.common import WindowsCommands
+from release_ccharp.utility.os_service import OsService
+
+
+class ChiasmaValidationDeployTests(unittest.TestCase):
+    def setUp(self):
+        config = {
+            "root_path": r'c:\tmp',
+            "git_repo_name": "chiasma",
+            "confluence_space_key": "CHI",
+            "owner": "GitEdvard"
+        }
+        branch_provider = FakeBranchProvider()
+        wf = SnpseqWorkflow(whatif=False, repo="chiasma")
+        wf.config = config
+        wf.paths.config = config
+        wf.paths.branch_provider = branch_provider
+        self.chiasma = Application(wf, branch_provider, OsService(),
+                                   WindowsCommands(), whatif=False)
+
+    #@skip("Acts on hard disk. Requires a validation dir and target file Chiasma.exe in validation dir")
+    def test_create_shortcut(self):
+        self.chiasma.validation_deployer.create_shortcut()
+
+    #@skip("Acts on hard disk. Requires a validation dir, target file Chiasma.exe in validation dir")
+    def test_extract_shortcut_target(self):
+        shortcut_path = r'c:\tmp\chiasma\uservalidations\latest\chiasma.lnk'
+        target = self.chiasma.validation_deployer.extract_shortcut_target(shortcut_path)
+        self.assertEqual(r'c:\tmp\chiasma\candidates\new-candidate\validation\chiasma.exe',
+                         target.lower())
+
+
+class FakeBranchProvider:
+    def __init__(self):
+        self.candidate_version = "1.0.0"
+        self.latest_version = "latest-version"
+        self.candidate_branch = "new-candidate"

--- a/tests/unit/chiasma_build_tests_unit.py
+++ b/tests/unit/chiasma_build_tests_unit.py
@@ -61,13 +61,13 @@ line 3"""
 
     def test_transform_config__with_validation_directory__orig_file_backed_up(self):
         validation_dir = r'c:\xxx\chiasma\candidates\validation'
-        self.chiasma._transform_config(validation_dir)
+        self.chiasma.chiasma_builder._transform_config(validation_dir)
         backuped_file = r'c:\xxx\chiasma\candidates\validation\chiasma.exe.config.orig'
         self.assertTrue(self.os_module.path.exists(backuped_file))
 
     def test_transform_config__with_validation_directory__backed_up_config_one_changed_entry_ok(self):
         validation_dir = r'c:\xxx\chiasma\candidates\validation'
-        self.chiasma._transform_config(validation_dir)
+        self.chiasma.chiasma_builder._transform_config(validation_dir)
         config_file_path = r'c:\xxx\chiasma\candidates\validation\chiasma.exe.config.orig'
         with self.chiasma.open_xml(config_file_path, backup_origfile=False) as xml:
             config = StandardVSConfigXML(xml, "Molmed.Chiasma")
@@ -75,13 +75,13 @@ line 3"""
 
     def test_transform_config__with_validation_directory__lab_config_exists(self):
         validation_dir = r'c:\xxx\chiasma\candidates\validation'
-        self.chiasma._transform_config(validation_dir)
+        self.chiasma.chiasma_builder._transform_config(validation_dir)
         lab_config_file_path = r'c:\xxx\chiasma\candidates\validation\config_lab\chiasma.exe.config'
         self.assertTrue(self.os_module.path.exists(lab_config_file_path))
 
     def test_transform_config__with_validation_directory__xml_update_ok_in_office_config(self):
         validation_dir = r'c:\xxx\chiasma\candidates\validation'
-        self.chiasma._transform_config(validation_dir)
+        self.chiasma.chiasma_builder._transform_config(validation_dir)
         config_file_path = r'c:\xxx\chiasma\candidates\validation\chiasma.exe.config'
         with self.chiasma.open_xml(config_file_path, backup_origfile=False) as xml:
             config = StandardVSConfigXML(xml, "Molmed.Chiasma")
@@ -96,7 +96,7 @@ line 3"""
 
     def test_transform_config__with_validation_directory__lab_config_update_ok(self):
         validation_dir = r'c:\xxx\chiasma\candidates\validation'
-        self.chiasma._transform_config(validation_dir)
+        self.chiasma.chiasma_builder._transform_config(validation_dir)
         config_file_path = r'c:\xxx\chiasma\candidates\validation\config_lab\chiasma.exe.config'
         with self.chiasma.open_xml(config_file_path, backup_origfile=False) as xml:
             config = StandardVSConfigXML(xml, "Molmed.Chiasma")
@@ -119,7 +119,7 @@ row3"""
         file_path = (r'c:\xxx\chiasma\candidates\new-candidate\GitEdvard-chiasma-123\chiasma'
                      r'\properties\AssemblyInfo.cs')
         self.filesystem.CreateFile(file_path, contents=contents)
-        self.chiasma.update_binary_version()
+        self.chiasma.chiasma_builder.update_binary_version()
         file_module = FakeFileOpen(self.filesystem)
         with file_module(file_path) as f:
             contents = "".join([line for line in f])

--- a/tests/unit/chiasma_build_tests_unit.py
+++ b/tests/unit/chiasma_build_tests_unit.py
@@ -126,7 +126,6 @@ row3"""
         self.assertEqual(expected, contents)
 
 
-
 class FakeBranchProvider:
     def __init__(self):
         self.candidate_version = "1.0.0"

--- a/tests/unit/chiasma_build_tests_unit.py
+++ b/tests/unit/chiasma_build_tests_unit.py
@@ -8,6 +8,7 @@ from release_ccharp.snpseq_workflow import SnpseqWorkflow
 from release_ccharp.apps.common import StandardVSConfigXML
 from tests.unit.utility.fake_os_service import FakeOsService
 from tests.unit.utility.config import CHIASMA_CONFIG
+from tests.unit.utility.fake_windows_commands import FakeWindowsCommands
 
 
 class ChiasmaBuildTests(unittest.TestCase):
@@ -32,7 +33,8 @@ class ChiasmaBuildTests(unittest.TestCase):
         # Instantiate chiasma class (Application)
         os_service = FakeOsService(self.filesystem)
         self.os_module = os_service.os_module
-        self.chiasma = Application(wf, branch_provider, os_service, whatif=False)
+        self.chiasma = Application(wf, branch_provider, os_service,
+                                   FakeWindowsCommands(self.filesystem), whatif=False)
 
     def test__get_version(self):
         version = self.chiasma.branch_provider.candidate_version

--- a/tests/unit/chiasma_validation_deploy_tests.py
+++ b/tests/unit/chiasma_validation_deploy_tests.py
@@ -2,8 +2,8 @@ import unittest
 from unittest import skip
 from pyfakefs import fake_filesystem
 from release_ccharp.snpseq_workflow import SnpseqWorkflow
-from release_ccharp.snpseq_paths import SnpseqPathActions
 from release_ccharp.apps.chiasma import Application
+from release_ccharp.utils import create_dirs
 from tests.unit.utility.fake_os_service import FakeOsService
 from tests.unit.utility.fake_windows_commands import FakeWindowsCommands
 
@@ -26,9 +26,8 @@ class ChiasmaValidationDeployTests(unittest.TestCase):
         self.chiasma = Application(wf, branch_provider, os_service,
                                    FakeWindowsCommands(self.filesystem), whatif=False)
 
-        path_actions = SnpseqPathActions(False, self.chiasma.path_properties, os_service)
-        path_actions.create_dirs(r'c:\xxx\chiasma\candidates\new-candidate\validation')
-        path_actions.create_dirs(r'c:\xxx\chiasma\uservalidations\latest')
+        create_dirs(os_service, r'c:\xxx\chiasma\candidates\release-1.0.0\validation')
+        create_dirs(os_service, r'c:\xxx\chiasma\uservalidations\latest\validationfiles')
 
     def test_create_shortcut__with_latest_empty__something_is_copied_to_latest(self):
         self.chiasma.validation_deployer.create_shortcut()

--- a/tests/unit/chiasma_validation_deploy_tests.py
+++ b/tests/unit/chiasma_validation_deploy_tests.py
@@ -45,7 +45,7 @@ class ChiasmaValidationDeployTests(unittest.TestCase):
 
     def test_create_shortcut__with_target_exists_in_candidates__extract_shortcut_target_works(self):
         # Arrange
-        fake_target_path = r'c:\xxx\chiasma\candidates\new-candidate\validation\chiasma.exe'
+        fake_target_path = r'c:\xxx\chiasma\candidates\release-1.0.0\validation\chiasma.exe'
         self.filesystem.CreateFile(fake_target_path)
         dest_shortcut_path = r'c:\xxx\chiasma\uservalidations\latest\chiasma.lnk'
 
@@ -54,11 +54,37 @@ class ChiasmaValidationDeployTests(unittest.TestCase):
         shortcut_target = self.chiasma.validation_deployer.extract_shortcut_target(dest_shortcut_path)
 
         #Assert
-        self.assertEqual(r'c:\xxx\chiasma\candidates\new-candidate\validation\Chiasma.exe', shortcut_target)
+        self.assertEqual(r'c:\xxx\chiasma\candidates\release-1.0.0\validation\Chiasma.exe', shortcut_target)
+
+    def test_copy_from_next__with_latest_dir_empty__copied_files_exists_in_latest(self):
+        # Arrange
+        validation_file = r'c:\xxx\chiasma\uservalidations\allversions\_next_release\validation_file.txt'
+        self.filesystem.CreateFile(validation_file)
+
+        # Act
+        self.chiasma.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\chiasma\uservalidations\latest\validationfiles\validation_file.txt'
+        self.assertTrue(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_hotfix_candidate__files_copied_from_next_hotfix(self):
+        # Arrange
+        validation_file = r'c:\xxx\chiasma\uservalidations\allversions\_next_hotfix\validation_file.txt'
+        self.filesystem.CreateFile(validation_file)
+        self.chiasma.branch_provider.candidate_branch = "hotfix-1.0.1"
+
+        # Act
+        self.chiasma.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\chiasma\uservalidations\latest\validationfiles\validation_file.txt'
+        self.assertTrue(self.os_module.path.exists(copied_file))
+
 
 
 class FakeBranchProvider:
     def __init__(self):
         self.candidate_version = "1.0.0"
         self.latest_version = "latest-version"
-        self.candidate_branch = "new-candidate"
+        self.candidate_branch = "release-1.0.0"

--- a/tests/unit/chiasma_validation_deploy_tests.py
+++ b/tests/unit/chiasma_validation_deploy_tests.py
@@ -55,7 +55,7 @@ class ChiasmaValidationDeployTests(unittest.TestCase):
         shortcut_target = self.chiasma.validation_deployer.extract_shortcut_target(dest_shortcut_path)
 
         #Assert
-        self.assertEqual(r'c:\xxx\chiasma\candidates\new-candidate\validation\chiasma.exe', shortcut_target)
+        self.assertEqual(r'c:\xxx\chiasma\candidates\new-candidate\validation\Chiasma.exe', shortcut_target)
 
 
 class FakeBranchProvider:

--- a/tests/unit/chiasma_validation_deploy_tests.py
+++ b/tests/unit/chiasma_validation_deploy_tests.py
@@ -247,7 +247,7 @@ class FileSystemBuilder:
         self.filesystem = filesystem
 
     def add_shortcut(self, candidate_dir='release-1.0.0'):
-        cand_path = os.path.join(self.chiasma.path_properties.candidate_root_path, candidate_dir)
+        cand_path = os.path.join(self.chiasma.path_properties.root_candidates, candidate_dir)
         current_shortcut_target = os.path.join(cand_path, r'buildpath\chiasma.exe')
         shortcut_save_path = os.path.join(self.chiasma.path_properties.user_validations_latest, r'chiasma.lnk')
         self.chiasma.windows_commands.create_shortcut(shortcut_save_path, current_shortcut_target)
@@ -270,7 +270,7 @@ class FileSystemBuilder:
         :param filename:
         :return:
         """
-        path = os.path.join(self.chiasma.path_properties.validation_archive_dir, filename)
+        path = os.path.join(self.chiasma.path_properties.archive_dir_validation_files, filename)
         self.filesystem.CreateFile(path, contents=contents)
 
     def get_contents(self, path):

--- a/tests/unit/chiasma_validation_deploy_tests.py
+++ b/tests/unit/chiasma_validation_deploy_tests.py
@@ -1,0 +1,63 @@
+import unittest
+from unittest import skip
+from pyfakefs import fake_filesystem
+from release_ccharp.snpseq_workflow import SnpseqWorkflow
+from release_ccharp.snpseq_paths import SnpseqPathActions
+from release_ccharp.apps.chiasma import Application
+from tests.unit.utility.fake_os_service import FakeOsService
+
+
+class ChiasmaValidationDeployTests(unittest.TestCase):
+    def setUp(self):
+        config = {
+            "root_path": r'c:\xxx',
+            "git_repo_name": "chiasma",
+            "owner": "GitEdvard"
+        }
+        branch_provider = FakeBranchProvider()
+        wf = SnpseqWorkflow(whatif=False, repo="chiasma")
+        wf.config = config
+        wf.paths.config = config
+        wf.paths.branch_provider = branch_provider
+        self.filesystem = fake_filesystem.FakeFilesystem()
+        os_service = FakeOsService(self.filesystem)
+        self.os_module = os_service.os_module
+        self.chiasma = Application(wf, branch_provider, os_service, whatif=False)
+
+        path_actions = SnpseqPathActions(False, self.chiasma.path_properties, os_service)
+        path_actions.create_dirs(r'c:\xxx\chiasma\candidates\new-candidate\validation')
+        path_actions.create_dirs(r'c:\xxx\chiasma\uservalidations\latest')
+
+    def test_create_shortcut__with_latest_empty__something_is_copied_to_latest(self):
+        self.chiasma.validation_deployer.create_shortcut()
+        self.assertTrue(self.os_module.path.exists(r'c:\xxx\chiasma\uservalidations\latest\chiasma.lnk'))
+
+    def test_create_shortcut__with_shortcut_exists_in_target__copy_without_error(self):
+        fake_destination_link = r'c:\xxx\chiasma\uservalidations\latest\chiasma.lnk'
+        self.filesystem.CreateFile(fake_destination_link)
+
+        # Act
+        self.chiasma.validation_deployer.create_shortcut()
+
+        # Assert
+        self.assertTrue(self.os_module.path.exists(r'c:\xxx\chiasma\uservalidations\latest\chiasma.lnk'))
+
+    def test_create_shortcut__with_target_exists_in_candidates__extract_shortcut_target_works(self):
+        # Arrange
+        fake_target_path = r'c:\xxx\chiasma\candidates\new-candidate\validation\chiasma.exe'
+        self.filesystem.CreateFile(fake_target_path)
+        dest_shortcut_path = r'c:\xxx\chiasma\uservalidations\latest\chiasma.lnk'
+
+        # Act
+        self.chiasma.validation_deployer.create_shortcut()
+        shortcut_target = self.chiasma.validation_deployer.extract_shortcut_target(dest_shortcut_path)
+
+        #Assert
+        self.assertEqual(r'c:\xxx\chiasma\candidates\new-candidate\validation\chiasma.exe', shortcut_target)
+
+
+class FakeBranchProvider:
+    def __init__(self):
+        self.candidate_version = "1.0.0"
+        self.latest_version = "latest-version"
+        self.candidate_branch = "new-candidate"

--- a/tests/unit/chiasma_validation_deploy_tests.py
+++ b/tests/unit/chiasma_validation_deploy_tests.py
@@ -5,6 +5,7 @@ from release_ccharp.snpseq_workflow import SnpseqWorkflow
 from release_ccharp.snpseq_paths import SnpseqPathActions
 from release_ccharp.apps.chiasma import Application
 from tests.unit.utility.fake_os_service import FakeOsService
+from tests.unit.utility.fake_windows_commands import FakeWindowsCommands
 
 
 class ChiasmaValidationDeployTests(unittest.TestCase):
@@ -22,7 +23,8 @@ class ChiasmaValidationDeployTests(unittest.TestCase):
         self.filesystem = fake_filesystem.FakeFilesystem()
         os_service = FakeOsService(self.filesystem)
         self.os_module = os_service.os_module
-        self.chiasma = Application(wf, branch_provider, os_service, whatif=False)
+        self.chiasma = Application(wf, branch_provider, os_service,
+                                   FakeWindowsCommands(self.filesystem), whatif=False)
 
         path_actions = SnpseqPathActions(False, self.chiasma.path_properties, os_service)
         path_actions.create_dirs(r'c:\xxx\chiasma\candidates\new-candidate\validation')

--- a/tests/unit/chiasma_validation_deploy_tests.py
+++ b/tests/unit/chiasma_validation_deploy_tests.py
@@ -1,7 +1,9 @@
 import unittest
+import os
 from unittest import skip
 from pyfakefs import fake_filesystem
 from release_ccharp.snpseq_workflow import SnpseqWorkflow
+from release_ccharp.snpseq_paths import SnpseqPathActions
 from release_ccharp.apps.chiasma import Application
 from release_ccharp.utils import create_dirs
 from tests.unit.utility.fake_os_service import FakeOsService
@@ -25,9 +27,13 @@ class ChiasmaValidationDeployTests(unittest.TestCase):
         self.os_module = os_service.os_module
         self.chiasma = Application(wf, branch_provider, os_service,
                                    FakeWindowsCommands(self.filesystem), whatif=False)
+        self.file_builder = FileSystemBuilder(self.chiasma, self.filesystem)
 
-        create_dirs(os_service, r'c:\xxx\chiasma\candidates\release-1.0.0\validation')
-        create_dirs(os_service, r'c:\xxx\chiasma\uservalidations\latest\validationfiles')
+        path_actions = SnpseqPathActions(
+            whatif=False, snpseq_path_properties=self.chiasma.path_properties,
+            os_service=os_service
+        )
+        path_actions.generate_folder_tree()
 
     def test_create_shortcut__with_latest_empty__something_is_copied_to_latest(self):
         self.chiasma.validation_deployer.create_shortcut()
@@ -58,8 +64,10 @@ class ChiasmaValidationDeployTests(unittest.TestCase):
 
     def test_copy_from_next__with_latest_dir_empty__copied_files_exists_in_latest(self):
         # Arrange
-        validation_file = r'c:\xxx\chiasma\uservalidations\allversions\_next_release\validation_file.txt'
+        validation_file = \
+            r'c:\xxx\chiasma\uservalidations\allversions\_next_release\validationfiles\validation_file.txt'
         self.filesystem.CreateFile(validation_file)
+        self.file_builder.add_shortcut()
 
         # Act
         self.chiasma.validation_deployer.copy_validation_files()
@@ -70,9 +78,11 @@ class ChiasmaValidationDeployTests(unittest.TestCase):
 
     def test_copy_from_next__with_hotfix_candidate__files_copied_from_next_hotfix(self):
         # Arrange
-        validation_file = r'c:\xxx\chiasma\uservalidations\allversions\_next_hotfix\validation_file.txt'
+        validation_file = \
+            r'c:\xxx\chiasma\uservalidations\allversions\_next_hotfix\validationfiles\validation_file.txt'
         self.filesystem.CreateFile(validation_file)
         self.chiasma.branch_provider.candidate_branch = "hotfix-1.0.1"
+        self.file_builder.add_shortcut()
 
         # Act
         self.chiasma.validation_deployer.copy_validation_files()
@@ -81,6 +91,147 @@ class ChiasmaValidationDeployTests(unittest.TestCase):
         copied_file = r'c:\xxx\chiasma\uservalidations\latest\validationfiles\validation_file.txt'
         self.assertTrue(self.os_module.path.exists(copied_file))
 
+    def test_copy_from_next__with_branch_and_shortcut_different__validation_files_copied_latest_to_archive(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_latest('old_validation_file.txt')
+        self.file_builder.add_validation_file_in_next('new_validation_file.txt')
+
+        # Act
+        self.chiasma.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\chiasma\uservalidations\allversions\0.1.0\validationfiles\old_validation_file.txt'
+        self.assertTrue(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_branch_and_shortcut_different__shortcut_copied_to_archive(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_latest('old_validation_file.txt')
+        self.file_builder.add_validation_file_in_next('new_validation_file.txt')
+
+        # Act
+        self.chiasma.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\chiasma\uservalidations\allversions\0.1.0\chiasma.lnk'
+        self.assertTrue(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_branch_and_shortcut_different__sql_script_not_copied_to_archive(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_latest('old_validation_file.txt')
+        self.file_builder.add_validation_file_in_next('new_validation_file.txt')
+        self.file_builder.add_sql_script_in_next('script1.sql')
+
+        # Act
+        self.chiasma.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\chiasma\uservalidations\allversions\0.1.0\sqlupdates\script1.sql'
+        self.assertFalse(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_branch_and_shortcut_different__file_deleted_in_latest(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_latest('old_validation_file.txt')
+        self.file_builder.add_validation_file_in_next('new_validation_file.txt')
+
+        # Act
+        self.chiasma.validation_deployer.copy_validation_files()
+
+        # Assert
+        old_file = r'c:\xxx\chiasma\uservalidations\latest\validationfiles\old_validation_file.txt'
+        self.assertFalse(self.os_module.path.exists(old_file))
+
+    def test_copy_from_next__with_branch_and_shortcut_same__validation_files_not_copied_to_archive(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        self.file_builder.add_validation_file_in_latest('old_validation_file.txt')
+        self.file_builder.add_validation_file_in_next('new_validation_file.txt')
+
+        # Act
+        self.chiasma.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\chiasma\uservalidations\allversions\1.0.0\validationfiles\old_validation_file.txt'
+        self.assertFalse(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_file_in_archive__file_exists_in_latest(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_archive('validation_file.txt')
+
+        # Act
+        self.chiasma.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\chiasma\uservalidations\latest\validationfiles\validation_file.txt'
+        self.assertTrue(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_file_in_archive__file_removed_in_archive(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_archive('validation_file.txt')
+
+        # Act
+        self.chiasma.validation_deployer.copy_validation_files()
+
+        # Assert
+        source_file = r'c:\xxx\chiasma\uservalidations\allversions\1.0.0\validationfiles\validation_file.txt'
+        self.assertFalse(self.os_module.path.exists(source_file))
+
+    def test_copy_from_next__with_file_in_archive__file_from_next_in_latest(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_archive('validation_file.txt')
+        self.file_builder.add_validation_file_in_next('file_from_next.txt')
+
+        # Act
+        self.chiasma.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\chiasma\uservalidations\latest\validationfiles\file_from_next.txt'
+        self.assertTrue(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_same_file_in_next_and_archive__archive_file_in_latest(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_archive('validation_file.txt', contents='archive')
+        self.file_builder.add_validation_file_in_next('validation_file.txt', contents='next')
+
+        # Act
+        self.chiasma.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\chiasma\uservalidations\latest\validationfiles\validation_file.txt'
+        self.assertEqual('archive', self.file_builder.get_contents(copied_file))
+
+    def test_copy_from_next__shortcut_nonexistent_in_latest__plain_copy(self):
+        # Arrange
+        self.file_builder.add_validation_file_in_next('validation_file.txt')
+
+        # Act
+        self.chiasma.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\chiasma\uservalidations\latest\validationfiles\validation_file.txt'
+        self.assertTrue(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__ordinary_setup__only_one_catalog_and_shortcut_in_latest(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        self.file_builder.add_validation_file_in_next('validation_file.txt')
+
+        # Act
+        self.chiasma.validation_deployer.copy_validation_files()
+
+        # Assert
+        latest = r'c:\xxx\chiasma\uservalidations\latest'
+        dir_objects = [o for o in self.chiasma.os_service.listdir(latest)]
+        self.assertEqual(2, len(dir_objects))
+
+
 
 
 class FakeBranchProvider:
@@ -88,3 +239,43 @@ class FakeBranchProvider:
         self.candidate_version = "1.0.0"
         self.latest_version = "latest-version"
         self.candidate_branch = "release-1.0.0"
+
+
+class FileSystemBuilder:
+    def __init__(self, chiasma, filesystem):
+        self.chiasma = chiasma
+        self.filesystem = filesystem
+
+    def add_shortcut(self, candidate_dir='release-1.0.0'):
+        cand_path = os.path.join(self.chiasma.path_properties.candidate_root_path, candidate_dir)
+        current_shortcut_target = os.path.join(cand_path, r'buildpath\chiasma.exe')
+        shortcut_save_path = os.path.join(self.chiasma.path_properties.user_validations_latest, r'chiasma.lnk')
+        self.chiasma.windows_commands.create_shortcut(shortcut_save_path, current_shortcut_target)
+
+    def add_validation_file_in_latest(self, filename='validationfile.txt', contents=''):
+        path = os.path.join(self.chiasma.path_properties.latest_validation_files, filename)
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def add_validation_file_in_next(self, filename='validationfile.txt', contents=''):
+        path = os.path.join(self.chiasma.path_properties.next_validation_files, filename)
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def add_sql_script_in_next(self, filename='script1.sql', contents=''):
+        path = os.path.join(self.chiasma.path_properties.next_sql_updates, filename)
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def add_validation_file_in_archive(self, filename='validationfile.txt', contents=''):
+        """
+        Put it in folder matching the candidate version
+        :param filename:
+        :return:
+        """
+        path = os.path.join(self.chiasma.path_properties.validation_archive_dir, filename)
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def get_contents(self, path):
+        c = None
+        with self.chiasma.os_service.open(path, 'r') as f:
+            c = f.read()
+        return c
+

--- a/tests/unit/copytree_preserve_existing_tests.py
+++ b/tests/unit/copytree_preserve_existing_tests.py
@@ -1,0 +1,62 @@
+import unittest
+from pyfakefs import fake_filesystem
+from release_ccharp.utils import copytree_preserve_existing
+from release_ccharp.utils import create_dirs
+from tests.unit.utility.fake_os_service import FakeOsService
+
+
+class TestCopyTree(unittest.TestCase):
+    def setUp(self):
+        self.filesystem = fake_filesystem.FakeFilesystem()
+        self.os_service = FakeOsService(self.filesystem)
+        self.source = r'c:\src'
+        self.dest = r'c:\dst'
+        create_dirs(self.os_service, self.source)
+        create_dirs(self.os_service, self.dest)
+
+    def test__with_one_file_in_source_dest_empty__file_copied(self):
+        self.filesystem.CreateFile(r'c:\src\file1.txt')
+        copytree_preserve_existing(self.os_service, self.source, self.dest)
+        self.assertTrue(self.os_service.exists(r'c:\dst\file1.txt'))
+
+    def test__with_two_files_in_source_dest_have_one_file__file_copied(self):
+        self.filesystem.CreateFile(r'c:\src\file1.txt')
+        self.filesystem.CreateFile(r'c:\src\file2.txt')
+        self.filesystem.CreateFile(r'c:\dst\file1.txt')
+        copytree_preserve_existing(self.os_service, self.source, self.dest)
+        self.assertTrue(self.os_service.exists(r'c:\dst\file2.txt'))
+
+    def test__with_subdir_and_single_file_in_source_dest_empty__file_copied(self):
+        create_dirs(self.os_service, r'c:\src\subdir')
+        self.filesystem.CreateFile(r'c:\src\subdir\file1.txt')
+        copytree_preserve_existing(self.os_service, self.source, self.dest)
+        self.assertTrue(self.os_service.exists(r'c:\dst\subdir\file1.txt'))
+
+    def test_complex_with_two_subdirs_in_source_one_exists_in_dest__file_copied(self):
+        create_dirs(self.os_service, r'c:\src\subdir1')
+        create_dirs(self.os_service, r'c:\src\subdir2')
+        create_dirs(self.os_service, r'c:\dst\subdir2')
+        self.filesystem.CreateFile(r'c:\src\file1.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir1\file2.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir1\file3.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir2\file4.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir2\file5.txt')
+        self.filesystem.CreateFile(r'c:\dst\subdir2\file4.txt')
+        copytree_preserve_existing(self.os_service, self.source, self.dest)
+
+        self.assertTrue(self.os_service.exists(r'c:\dst\file1.txt'))
+        self.assertTrue(self.os_service.exists(r'c:\dst\subdir1\file2.txt'))
+        self.assertTrue(self.os_service.exists(r'c:\dst\subdir1\file3.txt'))
+        self.assertTrue(self.os_service.exists(r'c:\dst\subdir2\file4.txt'))
+        self.assertTrue(self.os_service.exists(r'c:\dst\subdir2\file5.txt'))
+
+    def test__with_file_already_exists_in_destination__file_contents_preserved(self):
+        self.filesystem.CreateFile(r'c:\src\file1.txt', contents='new text')
+        self.filesystem.CreateFile(r'c:\dst\file1.txt', contents='original text')
+
+        copytree_preserve_existing(self.os_service, self.source, self.dest)
+
+        with self.os_service.open(r'c:\dst\file1.txt', 'r') as f:
+            contents = f.read()
+
+        self.assertEqual('original text', contents)

--- a/tests/unit/snpseq_path_actions_tests.py
+++ b/tests/unit/snpseq_path_actions_tests.py
@@ -1,0 +1,38 @@
+import unittest
+import re
+from pyfakefs import fake_filesystem
+from release_ccharp.snpseq_paths import SnpseqPathProperties
+from release_ccharp.snpseq_paths import SnpseqPathActions
+from tests.unit.utility.fake_os_service import FakeOsService
+
+
+class SnpseqPathActionsTests(unittest.TestCase):
+    def setUp(self):
+        config = {
+            "root_path": r'c:\xxx',
+            "git_repo_name": "chiasma",
+            "owner": "GitEdvard"
+        }
+        filesystem = fake_filesystem.FakeFilesystem()
+        self.path_properties = SnpseqPathProperties(config, "chiasma")
+        self.path_properties.branch_provider = FakeBranchProvider()
+        self.path_actions = SnpseqPathActions(whatif=False, snpseq_path_properties=self.path_properties,
+                                              os_service=FakeOsService(filesystem))
+
+    def test_find_version_from_candidate_path__with_release_candidate__returns_ok(self):
+        candidate_path = r'P:\lims\chiasma\candidates\release-1.18.0\build123\chiasma.exe'
+        version = self.path_actions.find_version_from_candidate_path(candidate_path)
+        self.assertEqual('1.18.0', version)
+
+    def test_regex(self):
+        text = r'a\release-1.0.0\b'
+        res = re.match(r'.*(release)-(\d+)\.(\d+)\.(\d+).*', text)
+        version = '{}.{}.{}'.format(res.group(2), res.group(3), res.group(4))
+        self.assertEqual('1.0.0', version)
+
+
+class FakeBranchProvider:
+    def __init__(self):
+        self.candidate_version = "1.0.0"
+        self.latest_version = "latest-version"
+        self.candidate_branch = "release-1.0.0"

--- a/tests/unit/snpseq_path_properties_test.py
+++ b/tests/unit/snpseq_path_properties_test.py
@@ -13,7 +13,7 @@ class SnpseqPathPropertiesTests(unittest.TestCase):
         self.path_properties.branch_provider = FakeBranchProvider()
 
     def test_validation_archive__with_branch_provider_as_below__path_is_right(self):
-        path = self.path_properties.validation_archive_dir
+        path = self.path_properties.archive_dir_validation_files
         self.assertEqual(r'c:\xxx\chiasma\UserValidations\AllVersions\1.0.0\ValidationFiles', path)
 
     def test_user_validations_latest(self):

--- a/tests/unit/snpseq_path_properties_test.py
+++ b/tests/unit/snpseq_path_properties_test.py
@@ -1,0 +1,24 @@
+import unittest
+from release_ccharp.snpseq_paths import SnpseqPathProperties
+
+
+class SnpseqPathPropertiesTests(unittest.TestCase):
+    def setUp(self):
+        config = {
+            "root_path": r'c:\xxx',
+            "git_repo_name": "chiasma",
+            "owner": "GitEdvard"
+        }
+        self.path_properties = SnpseqPathProperties(config, "chiasma")
+        self.path_properties.branch_provider = FakeBranchProvider()
+
+    def test_validation_archive__with_branch_provider_as_below__path_is_right(self):
+        path = self.path_properties.validation_archive_dir
+        self.assertEqual(r'c:\xxx\chiasma\UserValidations\AllVersions\1.0.0', path)
+
+
+class FakeBranchProvider:
+    def __init__(self):
+        self.candidate_version = "1.0.0"
+        self.latest_version = "latest-version"
+        self.candidate_branch = "release-1.0.0"

--- a/tests/unit/snpseq_path_properties_test.py
+++ b/tests/unit/snpseq_path_properties_test.py
@@ -14,7 +14,15 @@ class SnpseqPathPropertiesTests(unittest.TestCase):
 
     def test_validation_archive__with_branch_provider_as_below__path_is_right(self):
         path = self.path_properties.validation_archive_dir
-        self.assertEqual(r'c:\xxx\chiasma\UserValidations\AllVersions\1.0.0', path)
+        self.assertEqual(r'c:\xxx\chiasma\UserValidations\AllVersions\1.0.0\ValidationFiles', path)
+
+    def test_user_validations_latest(self):
+        path = self.path_properties.user_validations_latest
+        self.assertEqual(r'c:\xxx\chiasma\UserValidations\Latest', path)
+
+    def test_latest_validation_files(self):
+        path = self.path_properties.latest_validation_files
+        self.assertEqual(r'c:\xxx\chiasma\UserValidations\Latest\ValidationFiles', path)
 
 
 class FakeBranchProvider:

--- a/tests/unit/utility/fake_os_service.py
+++ b/tests/unit/utility/fake_os_service.py
@@ -18,6 +18,9 @@ class FakeOsService:
     def isdir(self, path):
         return self.os_module.path.isdir(path)
 
+    def isfile(self, path):
+        return self.os_module.path.isfile(path)
+
     def copytree(self, src, dst):
         self.shutil_module.copytree(src, dst)
 
@@ -59,3 +62,9 @@ class FakeOsService:
         file_module.read = read
         file_module.write = write
         yield file_module
+
+    def remove_file(self, path):
+        self.os_module.unlink(path)
+
+    def rmtree(self, path):
+        self.shutil_module.rmtree(path)

--- a/tests/unit/utility/fake_windows_commands.py
+++ b/tests/unit/utility/fake_windows_commands.py
@@ -1,0 +1,14 @@
+from pyfakefs.fake_filesystem import FakeOsModule
+
+
+class FakeWindowsCommands:
+    def __init__(self, filesystem):
+        self.filesystem = filesystem
+        self.os_module = FakeOsModule(filesystem)
+
+    def build_solution(self):
+        pass
+
+    def create_shortcut(self, save_path, target_path):
+        if not self.os_module.path.exists(save_path):
+            self.filesystem.CreateFile(save_path)

--- a/tests/unit/utility/fake_windows_commands.py
+++ b/tests/unit/utility/fake_windows_commands.py
@@ -1,4 +1,5 @@
 from pyfakefs.fake_filesystem import FakeOsModule
+from pyfakefs.fake_filesystem import FakeFileOpen
 
 
 class FakeWindowsCommands:
@@ -11,4 +12,11 @@ class FakeWindowsCommands:
 
     def create_shortcut(self, save_path, target_path):
         if not self.os_module.path.exists(save_path):
-            self.filesystem.CreateFile(save_path)
+            self.filesystem.CreateFile(save_path, contents=target_path)
+
+    def extract_shortcut_target(self, shortcut_path):
+        file_module = FakeFileOpen(self.filesystem)
+        with file_module(shortcut_path) as f:
+            contents = "".join([line for line in f])
+        return contents
+

--- a/tests/unit/utils_tests.py
+++ b/tests/unit/utils_tests.py
@@ -1,6 +1,7 @@
 import unittest
 from pyfakefs import fake_filesystem
 from release_ccharp.utils import copytree_preserve_existing
+from release_ccharp.utils import delete_directory_contents
 from release_ccharp.utils import create_dirs
 from tests.unit.utility.fake_os_service import FakeOsService
 
@@ -60,3 +61,30 @@ class TestCopyTree(unittest.TestCase):
             contents = f.read()
 
         self.assertEqual('original text', contents)
+
+
+class TestDeleteDirectoryContents(unittest.TestCase):
+    def setUp(self):
+        self.filesystem = fake_filesystem.FakeFilesystem()
+        self.os_service = FakeOsService(self.filesystem)
+        self.file1 = r'c:\path1\file1.txt'
+        self.file2 = r'c:\path1\path2\file2.txt'
+        self.another_folder = r'c:\anotherfolder'
+        self.filesystem.CreateFile(self.file1)
+        self.filesystem.CreateFile(self.file2)
+        create_dirs(self.os_service, self.another_folder)
+
+    def test_doing_nothing__file1_exists(self):
+        self.assertTrue(self.os_service.exists(self.file1))
+
+    def test_remove_path1__file1_is_gone(self):
+        delete_directory_contents(self.os_service, r'c:\path1')
+        self.assertFalse(self.os_service.exists(self.file1))
+
+    def test_remove_path1__file2_is_gone(self):
+        delete_directory_contents(self.os_service, r'c:\path1')
+        self.assertFalse(self.os_service.exists(self.file2))
+
+    def test_remove_path1__anotherfolder_exists(self):
+        delete_directory_contents(self.os_service, r'c:\path1')
+        self.assertTrue(self.os_service.exists(self.another_folder))


### PR DESCRIPTION
Copy validation files and create a shortcut. Handle situation when validation period is interrupted by a hotfix. 

Automated tests: I have a fake file system (previous PR?)

utils: functions for copy tree preserve existing and delete folder contents. 

Deploy validation is here bound to the chiasma application, although most of the code can be re-used. 