### PR TITLE
Chi 699 chiasma deploy

### DIFF
--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -27,7 +27,8 @@ class Application(ApplicationBase):
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
         self.validation_deployer = ChiasmaValidationDeployer(
             self, file_deployer, path_actions)
-        self.deployer = ChiasmaDeployer(self.path_properties, file_deployer)
+        self.deployer = ChiasmaDeployer(
+            self.path_properties, file_deployer, path_actions, os_service, branch_provider)
 
     def build(self):
         self.chiasma_builder.run()

--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -4,6 +4,7 @@ from release_ccharp.apps.common.base import ApplicationBase
 from release_ccharp.apps.common.directory_handling import ValidationDeployer
 from release_ccharp.apps.chiasma_scripts.builder import ChiasmaBuilder
 from release_ccharp.apps.chiasma_scripts.validation_deployer import ChiasmaValidationDeployer
+from release_ccharp.apps.chiasma_scripts.deployer import ChiasmaDeployer
 
 
 class Application(ApplicationBase):
@@ -21,9 +22,13 @@ class Application(ApplicationBase):
         self.chiasma_builder = ChiasmaBuilder(self)
         validation_deployer = ValidationDeployer(self.path_properties, self.os_service)
         self.validation_deployer = ChiasmaValidationDeployer(self, validation_deployer)
+        self.deployer = ChiasmaDeployer(self.path_properties, self.app_paths, os_service)
 
     def build(self):
         self.chiasma_builder.run()
 
     def deploy_validation(self):
         self.validation_deployer.run()
+
+    def deploy(self):
+        self.deployer.run()

--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -39,3 +39,7 @@ class Application(ApplicationBase):
 
     def deploy(self):
         self.deployer.run()
+
+    def download_release_history(self):
+        self.snpseq_workflow.download_release_history()
+        self.deployer.copy_release_history()

--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -22,7 +22,8 @@ class Application(ApplicationBase):
         self.chiasma_builder = ChiasmaBuilder(self)
         validation_deployer = ValidationDeployer(self.path_properties, self.os_service)
         self.validation_deployer = ChiasmaValidationDeployer(self, validation_deployer)
-        self.deployer = ChiasmaDeployer(self.path_properties, self.app_paths, os_service)
+        self.deployer = ChiasmaDeployer(
+            self.path_properties, self.app_paths, os_service, snpseq_workflow.config)
 
     def build(self):
         self.chiasma_builder.run()

--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -2,9 +2,11 @@ from __future__ import print_function
 from release_ccharp.apps.common.single_file_read_write import BinaryVersionUpdater
 from release_ccharp.apps.common.base import ApplicationBase
 from release_ccharp.apps.common.directory_handling import ValidationDeployer
+from release_ccharp.apps.common.directory_handling import Deployer
 from release_ccharp.apps.chiasma_scripts.builder import ChiasmaBuilder
 from release_ccharp.apps.chiasma_scripts.validation_deployer import ChiasmaValidationDeployer
 from release_ccharp.apps.chiasma_scripts.deployer import ChiasmaDeployer
+from release_ccharp.snpseq_paths import SnpseqPathActions
 
 
 class Application(ApplicationBase):
@@ -21,9 +23,13 @@ class Application(ApplicationBase):
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         self.chiasma_builder = ChiasmaBuilder(self)
         validation_deployer = ValidationDeployer(self.path_properties, self.os_service)
-        self.validation_deployer = ChiasmaValidationDeployer(self, validation_deployer)
-        self.deployer = ChiasmaDeployer(
-            self.path_properties, self.app_paths, os_service, snpseq_workflow.config)
+        path_actions = SnpseqPathActions(
+            whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
+        self.validation_deployer = ChiasmaValidationDeployer(
+            self, validation_deployer, path_actions)
+        common_deployer = Deployer(
+            self.path_properties, os_service, snpseq_workflow.config, self.app_paths)
+        self.deployer = ChiasmaDeployer(self.path_properties, common_deployer)
 
     def build(self):
         self.chiasma_builder.run()

--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -31,14 +31,18 @@ class Application(ApplicationBase):
             self.path_properties, file_deployer, path_actions, os_service, branch_provider)
 
     def build(self):
+        super(Application, self).build()
         self.chiasma_builder.run()
 
     def deploy_validation(self):
+        super(Application, self).deploy_validation()
         self.validation_deployer.run()
 
     def deploy(self):
+        super(Application, self).deploy()
         self.deployer.run()
 
     def download_release_history(self):
+        super(Application, self).download_release_history()
         self.snpseq_workflow.download_release_history()
         self.deployer.copy_release_history()

--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -1,8 +1,7 @@
 from __future__ import print_function
 from release_ccharp.apps.common.single_file_read_write import BinaryVersionUpdater
 from release_ccharp.apps.common.base import ApplicationBase
-from release_ccharp.apps.common.directory_handling import ValidationDeployer
-from release_ccharp.apps.common.directory_handling import Deployer
+from release_ccharp.apps.common.directory_handling import FileDeployer
 from release_ccharp.apps.chiasma_scripts.builder import ChiasmaBuilder
 from release_ccharp.apps.chiasma_scripts.validation_deployer import ChiasmaValidationDeployer
 from release_ccharp.apps.chiasma_scripts.deployer import ChiasmaDeployer
@@ -22,14 +21,13 @@ class Application(ApplicationBase):
             whatif=False, config=self.config, path_properties=self.path_properties,
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         self.chiasma_builder = ChiasmaBuilder(self)
-        validation_deployer = ValidationDeployer(self.path_properties, self.os_service)
+        file_deployer = FileDeployer(
+            self.path_properties, self.os_service, snpseq_workflow.config, self.app_paths)
         path_actions = SnpseqPathActions(
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
         self.validation_deployer = ChiasmaValidationDeployer(
-            self, validation_deployer, path_actions)
-        common_deployer = Deployer(
-            self.path_properties, os_service, snpseq_workflow.config, self.app_paths)
-        self.deployer = ChiasmaDeployer(self.path_properties, common_deployer)
+            self, file_deployer, path_actions)
+        self.deployer = ChiasmaDeployer(self.path_properties, file_deployer)
 
     def build(self):
         self.chiasma_builder.run()

--- a/release_ccharp/apps/chiasma_scripts/builder.py
+++ b/release_ccharp/apps/chiasma_scripts/builder.py
@@ -52,7 +52,7 @@ class ChiasmaBuilder:
             config.update("DiluteTubeAutomaticLabelPrint", "True")
             config.update("DebugMode", "False")
             config.update("DatabaseName", db_name)
-        lab_config_dir = os.path.join(directory, "Config_lab")
+        lab_config_dir = os.path.join(directory, self.chiasma.path_properties.config_lab_subpath)
         create_dirs(self.chiasma.os_service, lab_config_dir, self.chiasma.whatif,
                     self.chiasma.whatif)
         lab_config_file_path = os.path.join(lab_config_dir, self.chiasma.app_paths.config_file_name)

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -1,0 +1,36 @@
+from __future__ import print_function
+import os
+
+
+class ChiasmaDeployer:
+    def __init__(self, path_properties, app_path, os_service):
+        self.path_properties = path_properties
+        self.app_paths = app_path
+        self.os_service = os_service
+
+    def run(self):
+        self.check_source_files_exists()
+
+    def check_source_files_exists(self):
+        print('Check that source files exists ...')
+
+        exe = os.path.join(self.app_paths.production_dir, 'Chiasma.exe')
+        config = os.path.join(self.app_paths.production_dir, self.app_paths.config_file_name)
+        config_lab = os.path.join(
+            self.app_paths.production_config_lab_dir, self.app_paths.config_file_name)
+        user_manual = self.path_properties.user_manual_download_path
+
+        if not self.os_service.exists(exe):
+            raise FileDoesNotExistsException(exe)
+        if not self.os_service.exists(config):
+            raise FileDoesNotExistsException(config)
+        if not self.os_service.exists(config_lab):
+            raise FileDoesNotExistsException(config_lab)
+        if not self.os_service.exists(user_manual):
+            raise FileDoesNotExistsException(user_manual)
+
+        print('ok')
+
+
+class FileDoesNotExistsException(Exception):
+    pass

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from release_ccharp.utils import copytree_replace_existing
 
 
 class ChiasmaDeployer:
@@ -8,6 +9,7 @@ class ChiasmaDeployer:
 
     def run(self):
         self.check_source_files_exists()
+        self.common_deployer.move_deploy_files()
 
     def check_source_files_exists(self):
         print('Check that source files exists ...')

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -10,6 +10,7 @@ class ChiasmaDeployer:
     def run(self):
         self.check_source_files_exists()
         self.common_deployer.move_deploy_files()
+        self.common_deployer.move_user_manual()
 
     def check_source_files_exists(self):
         print('Check that source files exists ...')

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -35,7 +35,9 @@ class ChiasmaDeployer:
         This method have to be called before the candidate version is accepted.
         :return:
         """
-        self.file_deployer.move_latest_to_archive(self.branch_provider.candidate_version)
-        self.file_deployer.move_sql_scripts_to_archive(self.branch_provider.candidate_version)
+        print('Move validation files and sql script to archive...')
+        self.file_deployer.move_latest_to_archive(str(self.branch_provider.candidate_version))
+        self.file_deployer.move_sql_scripts_to_archive(str(self.branch_provider.candidate_version))
         self.path_actions.create_shortcut_to_exe()
         delete_directory_contents(self.os_service, self.path_properties.next_validation_files)
+        print('ok')

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -1,16 +1,20 @@
 from __future__ import print_function
-from release_ccharp.utils import copytree_replace_existing
+from release_ccharp.utils import delete_directory_contents
 
 
 class ChiasmaDeployer:
-    def __init__(self, path_properties, file_deployer):
+    def __init__(self, path_properties, file_deployer, path_actions, os_service, branch_provider):
         self.path_properties = path_properties
         self.file_deployer = file_deployer
+        self.branch_provider = branch_provider
+        self.path_actions = path_actions
+        self.os_service = os_service
 
     def run(self):
         self.check_source_files_exists()
         self.file_deployer.move_deploy_files()
         self.file_deployer.move_user_manual()
+        self.move_to_archive()
 
     def check_source_files_exists(self):
         print('Check that source files exists ...')
@@ -24,3 +28,14 @@ class ChiasmaDeployer:
 
     def copy_release_history(self):
         self.file_deployer.copy_release_history()
+
+    def move_to_archive(self):
+        """
+        Move files to archive folder matching the current candidate
+        This method have to be called before the candidate version is accepted.
+        :return:
+        """
+        self.file_deployer.move_latest_to_archive(self.branch_provider.candidate_version)
+        self.file_deployer.move_sql_scripts_to_archive(self.branch_provider.candidate_version)
+        self.path_actions.create_shortcut_to_exe()
+        delete_directory_contents(self.os_service, self.path_properties.next_validation_files)

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -3,24 +3,24 @@ from release_ccharp.utils import copytree_replace_existing
 
 
 class ChiasmaDeployer:
-    def __init__(self, path_properties, common_deployer):
+    def __init__(self, path_properties, file_deployer):
         self.path_properties = path_properties
-        self.common_deployer = common_deployer
+        self.file_deployer = file_deployer
 
     def run(self):
         self.check_source_files_exists()
-        self.common_deployer.move_deploy_files()
-        self.common_deployer.move_user_manual()
+        self.file_deployer.move_deploy_files()
+        self.file_deployer.move_user_manual()
 
     def check_source_files_exists(self):
         print('Check that source files exists ...')
 
-        self.common_deployer.check_exe_file_exists()
-        self.common_deployer.check_config_file_exists()
-        self.common_deployer.check_config_lab_file_exists()
-        self.common_deployer.check_user_manual_exists()
+        self.file_deployer.check_exe_file_exists()
+        self.file_deployer.check_config_file_exists()
+        self.file_deployer.check_config_lab_file_exists()
+        self.file_deployer.check_user_manual_exists()
 
         print('ok')
 
     def copy_release_history(self):
-        self.common_deployer.copy_release_history()
+        self.file_deployer.copy_release_history()

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -3,10 +3,11 @@ import os
 
 
 class ChiasmaDeployer:
-    def __init__(self, path_properties, app_path, os_service):
+    def __init__(self, path_properties, app_path, os_service, config):
         self.path_properties = path_properties
         self.app_paths = app_path
         self.os_service = os_service
+        self.config = config
 
     def run(self):
         self.check_source_files_exists()
@@ -14,7 +15,8 @@ class ChiasmaDeployer:
     def check_source_files_exists(self):
         print('Check that source files exists ...')
 
-        exe = os.path.join(self.app_paths.production_dir, 'Chiasma.exe')
+        filename = '{}.exe'.format(self.config['exe_file_name_base'])
+        exe = os.path.join(self.app_paths.production_dir, filename)
         config = os.path.join(self.app_paths.production_dir, self.app_paths.config_file_name)
         config_lab = os.path.join(
             self.app_paths.production_config_lab_dir, self.app_paths.config_file_name)

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -21,3 +21,6 @@ class ChiasmaDeployer:
         self.common_deployer.check_user_manual_exists()
 
         print('ok')
+
+    def copy_release_history(self):
+        self.common_deployer.copy_release_history()

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -15,8 +15,8 @@ class ChiasmaDeployer:
     def check_source_files_exists(self):
         print('Check that source files exists ...')
 
-        filename = '{}.exe'.format(self.config['exe_file_name_base'])
-        exe = os.path.join(self.app_paths.production_dir, filename)
+        exe_filename = '{}.exe'.format(self.config['exe_file_name_base'])
+        exe = os.path.join(self.app_paths.production_dir, exe_filename)
         config = os.path.join(self.app_paths.production_dir, self.app_paths.config_file_name)
         config_lab = os.path.join(
             self.app_paths.production_config_lab_dir, self.app_paths.config_file_name)
@@ -30,7 +30,6 @@ class ChiasmaDeployer:
             raise FileDoesNotExistsException(config_lab)
         if not self.os_service.exists(user_manual):
             raise FileDoesNotExistsException(user_manual)
-
         print('ok')
 
 

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -1,13 +1,10 @@
 from __future__ import print_function
-import os
 
 
 class ChiasmaDeployer:
-    def __init__(self, path_properties, app_path, os_service, config):
+    def __init__(self, path_properties, common_deployer):
         self.path_properties = path_properties
-        self.app_paths = app_path
-        self.os_service = os_service
-        self.config = config
+        self.common_deployer = common_deployer
 
     def run(self):
         self.check_source_files_exists()
@@ -15,23 +12,9 @@ class ChiasmaDeployer:
     def check_source_files_exists(self):
         print('Check that source files exists ...')
 
-        exe_filename = '{}.exe'.format(self.config['exe_file_name_base'])
-        exe = os.path.join(self.app_paths.production_dir, exe_filename)
-        config = os.path.join(self.app_paths.production_dir, self.app_paths.config_file_name)
-        config_lab = os.path.join(
-            self.app_paths.production_config_lab_dir, self.app_paths.config_file_name)
-        user_manual = self.path_properties.user_manual_download_path
+        self.common_deployer.check_exe_file_exists()
+        self.common_deployer.check_config_file_exists()
+        self.common_deployer.check_config_lab_file_exists()
+        self.common_deployer.check_user_manual_exists()
 
-        if not self.os_service.exists(exe):
-            raise FileDoesNotExistsException(exe)
-        if not self.os_service.exists(config):
-            raise FileDoesNotExistsException(config)
-        if not self.os_service.exists(config_lab):
-            raise FileDoesNotExistsException(config_lab)
-        if not self.os_service.exists(user_manual):
-            raise FileDoesNotExistsException(user_manual)
         print('ok')
-
-
-class FileDoesNotExistsException(Exception):
-    pass

--- a/release_ccharp/apps/chiasma_scripts/validation_deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/validation_deployer.py
@@ -5,28 +5,18 @@ from release_ccharp.apps.common.single_file_read_write import ShortcutExaminer
 
 
 class ChiasmaValidationDeployer:
-    def __init__(self, chiasma, common_deployer):
+    def __init__(self, chiasma, common_deployer, path_actions):
         self.chiasma = chiasma
         self.common_deployer = common_deployer
         self.os_service = common_deployer.os_service
         self.shortcut_examiner = ShortcutExaminer(
             self.chiasma.branch_provider, self.os_service, self.chiasma.windows_commands,
-            common_deployer, self.shortcut_path
-        )
+            common_deployer, self.chiasma.path_properties.shortcut_path)
+        self.path_actions = path_actions
 
     def run(self):
         self.copy_validation_files()
-        self.create_shortcut()
-
-    @lazyprop
-    def shortcut_path(self):
-        filename = '{}.lnk'.format(self.chiasma.config['exe_file_name_base'])
-        return os.path.join(self.chiasma.path_properties.user_validations_latest, filename)
-
-    def create_shortcut(self):
-        exe_filename = '{}.exe'.format(self.chiasma.config['exe_file_name_base'])
-        shortcut_target = os.path.join(self.chiasma.app_paths.validation_dir, exe_filename)
-        self.chiasma.windows_commands.create_shortcut(self.shortcut_path, shortcut_target)
+        self.path_actions.create_shortcut_to_exe()
 
     def copy_validation_files(self):
         if not self.shortcut_examiner.is_candidate_in_latest:

--- a/release_ccharp/apps/chiasma_scripts/validation_deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/validation_deployer.py
@@ -5,13 +5,13 @@ from release_ccharp.apps.common.single_file_read_write import ShortcutExaminer
 
 
 class ChiasmaValidationDeployer:
-    def __init__(self, chiasma, common_deployer, path_actions):
+    def __init__(self, chiasma, file_deployer, path_actions):
         self.chiasma = chiasma
-        self.common_deployer = common_deployer
-        self.os_service = common_deployer.os_service
+        self.file_deployer = file_deployer
+        self.os_service = file_deployer.os_service
         self.shortcut_examiner = ShortcutExaminer(
             self.chiasma.branch_provider, self.os_service, self.chiasma.windows_commands,
-            common_deployer, self.chiasma.path_properties.shortcut_path)
+            file_deployer, self.chiasma.path_properties.shortcut_path)
         self.path_actions = path_actions
 
     def run(self):
@@ -20,7 +20,7 @@ class ChiasmaValidationDeployer:
 
     def copy_validation_files(self):
         if not self.shortcut_examiner.is_candidate_in_latest:
-            self.common_deployer.move_to_archive(self.shortcut_examiner.version_in_latest)
+            self.file_deployer.move_to_archive(self.shortcut_examiner.version_in_latest)
         if self.os_service.exists(self.chiasma.path_properties.archive_dir_validation_files):
-            self.common_deployer.back_move_from_archive()
-        self.common_deployer.copy_to_latest()
+            self.file_deployer.back_move_from_archive()
+        self.file_deployer.copy_to_latest()

--- a/release_ccharp/apps/chiasma_scripts/validation_deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/validation_deployer.py
@@ -20,10 +20,12 @@ class ChiasmaValidationDeployer:
 
     @lazyprop
     def shortcut_path(self):
-        return os.path.join(self.chiasma.path_properties.user_validations_latest, 'Chiasma.lnk')
+        filename = '{}.lnk'.format(self.chiasma.config['exe_file_name_base'])
+        return os.path.join(self.chiasma.path_properties.user_validations_latest, filename)
 
     def create_shortcut(self):
-        shortcut_target = os.path.join(self.chiasma.app_paths.validation_dir, 'Chiasma.exe')
+        exe_filename = '{}.exe'.format(self.chiasma.config['exe_file_name_base'])
+        shortcut_target = os.path.join(self.chiasma.app_paths.validation_dir, exe_filename)
         self.chiasma.windows_commands.create_shortcut(self.shortcut_path, shortcut_target)
 
     def copy_validation_files(self):

--- a/release_ccharp/apps/chiasma_scripts/validation_deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/validation_deployer.py
@@ -20,7 +20,7 @@ class ChiasmaValidationDeployer:
 
     def copy_validation_files(self):
         if not self.shortcut_examiner.is_candidate_in_latest:
-            self.file_deployer.move_to_archive(self.shortcut_examiner.version_in_latest)
+            self.file_deployer.move_latest_to_archive(self.shortcut_examiner.version_in_latest)
         if self.os_service.exists(self.chiasma.path_properties.archive_dir_validation_files):
             self.file_deployer.back_move_from_archive()
         self.file_deployer.copy_to_latest()

--- a/release_ccharp/apps/common/base.py
+++ b/release_ccharp/apps/common/base.py
@@ -38,19 +38,19 @@ class ApplicationBase(object):
 
     @abc.abstractmethod
     def build(self):
-        pass
+        print('Starting build')
 
     @abc.abstractmethod
     def deploy_validation(self):
-        pass
+        print('Starting deploy validation')
 
     @abc.abstractmethod
     def deploy(self):
-        pass
+        print('Starting deploy')
 
     @abc.abstractmethod
     def download_release_history(self):
-        pass
+        print('Starting download release history')
 
 
 class WindowsCommands:

--- a/release_ccharp/apps/common/base.py
+++ b/release_ccharp/apps/common/base.py
@@ -44,6 +44,10 @@ class ApplicationBase(object):
     def deploy_validation(self):
         pass
 
+    @abc.abstractmethod
+    def deploy(self):
+        pass
+
 
 class WindowsCommands:
     def build_solution(self, solution_file_path):

--- a/release_ccharp/apps/common/base.py
+++ b/release_ccharp/apps/common/base.py
@@ -79,7 +79,7 @@ class ApplicationFactory:
 
     def get_instance(self, whatif, repo):
         application = self.import_application(repo)
-        wf = SnpseqWorkflow(whatif, repo)
+        wf = SnpseqWorkflow(whatif, repo, OsService())
         branch_provider = wf.paths.branch_provider
         return application(wf, branch_provider, OsService(), WindowsCommands(), whatif)
 

--- a/release_ccharp/apps/common/base.py
+++ b/release_ccharp/apps/common/base.py
@@ -48,6 +48,10 @@ class ApplicationBase(object):
     def deploy(self):
         pass
 
+    @abc.abstractmethod
+    def download_release_history(self):
+        pass
+
 
 class WindowsCommands:
     def build_solution(self, solution_file_path):

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -133,8 +133,14 @@ class Deployer:
 
     def move_user_manual(self):
         src = self.path_properties.user_manual_download_path
-        dst = os.path.join(self.path_properties.docs, self.path_properties.user_manual_name)
+        dst = os.path.join(self.path_properties.doc, self.path_properties.user_manual_name)
         self.os_service.copyfile(src, dst)
+
+    def copy_release_history(self):
+        src_release_history = self.path_properties.latest_accepted_release_history
+        release_history_base_name = os.path.basename(src_release_history)
+        dst = os.path.join(self.path_properties.doc, release_history_base_name)
+        self.os_service.copyfile(src_release_history, dst)
 
 
 class FileDoesNotExistsException(Exception):

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -48,7 +48,7 @@ class AppPaths:
 
     @lazyprop
     def config_file_name(self):
-        return "{}.exe.config".format(self.config["git_repo_name"])
+        return "{}.exe.config".format(self.config["exe_file_name_base"])
 
     def move_candidates(self):
         release_subdir = os.path.join(self.config["git_repo_name"], r'bin\release')

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -59,22 +59,19 @@ class AppPaths:
         self.os_service.copytree(release_dir, self.production_dir)
 
 
-class ValidationDeployer:
-    def __init__(self, path_properties, os_service):
+class FileDeployer:
+    def __init__(self, path_properties, os_service, config, app_paths):
         self.path_properties = path_properties
         self.os_service = os_service
+        self.config = config
+        self.app_paths = app_paths
         self.path_actions = SnpseqPathActions(
             whatif=False, path_properties=self.path_properties,
             os_service=self.os_service)
 
-    def move_to_archive(self, version_in_latest):
-        """
-        If interrupting an ongoing test for a hotfix, move existing files to archive
-        Archive catalog is fetched from shortcut in latest, not the candidate branch
-        :return:
-        """
+    def move_to_archive(self, version):
         validation_dir = self.path_properties.user_validations_latest
-        target_dir = os.path.join(self.path_properties.all_versions, version_in_latest)
+        target_dir = os.path.join(self.path_properties.all_versions, version)
         copytree_preserve_existing(self.os_service, validation_dir, target_dir)
         delete_directory_contents(self.os_service, validation_dir)
 
@@ -95,14 +92,6 @@ class ValidationDeployer:
 
     def extract_version_from_path(self, path):
         return self.path_actions.find_version_from_candidate_path(path)
-
-
-class Deployer:
-    def __init__(self, path_properties, os_service, config, app_paths):
-        self.path_properties = path_properties
-        self.os_service = os_service
-        self.config = config
-        self.app_paths = app_paths
 
     def check_exe_file_exists(self):
         exe_filename = '{}.exe'.format(self.config['exe_file_name_base'])

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -122,20 +122,26 @@ class FileDeployer:
             raise FileDoesNotExistsException(user_manual)
 
     def move_deploy_files(self):
+        print('Copy files to deploy catalog...')
         src = self.app_paths.production_dir
         dst = self.app_paths.config['deploy_root_path']
         copytree_replace_existing(self.os_service, src, dst)
+        print('ok')
 
     def move_user_manual(self):
+        print('Copy user manual to doc catalog...')
         src = self.path_properties.user_manual_download_path
         dst = os.path.join(self.path_properties.doc, self.path_properties.user_manual_name)
         self.os_service.copyfile(src, dst)
+        print('ok')
 
     def copy_release_history(self):
+        print('Copy release history to doc catalog...')
         src_release_history = self.path_properties.latest_accepted_release_history
         release_history_base_name = os.path.basename(src_release_history)
         dst = os.path.join(self.path_properties.doc, release_history_base_name)
         self.os_service.copyfile(src_release_history, dst)
+        print('ok')
 
 
 class FileDoesNotExistsException(Exception):

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -131,6 +131,11 @@ class Deployer:
         dst = self.app_paths.config['deploy_root_path']
         copytree_replace_existing(self.os_service, src, dst)
 
+    def move_user_manual(self):
+        src = self.path_properties.user_manual_download_path
+        dst = os.path.join(self.path_properties.docs, self.path_properties.user_manual_name)
+        self.os_service.copyfile(src, dst)
+
 
 class FileDoesNotExistsException(Exception):
     pass

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -3,6 +3,7 @@ import os
 from release_ccharp.utils import lazyprop
 from release_ccharp.snpseq_paths import SnpseqPathActions
 from release_ccharp.utils import copytree_preserve_existing
+from release_ccharp.utils import copytree_replace_existing
 from release_ccharp.utils import delete_directory_contents
 
 
@@ -124,6 +125,11 @@ class Deployer:
         user_manual = self.path_properties.user_manual_download_path
         if not self.os_service.exists(user_manual):
             raise FileDoesNotExistsException(user_manual)
+
+    def move_deploy_files(self):
+        src = self.app_paths.production_dir
+        dst = self.app_paths.config['deploy_root_path']
+        copytree_replace_existing(self.os_service, src, dst)
 
 
 class FileDoesNotExistsException(Exception):

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -69,11 +69,17 @@ class FileDeployer:
             whatif=False, path_properties=self.path_properties,
             os_service=self.os_service)
 
-    def move_to_archive(self, version):
+    def move_latest_to_archive(self, version):
         validation_dir = self.path_properties.user_validations_latest
         target_dir = os.path.join(self.path_properties.all_versions, version)
         copytree_preserve_existing(self.os_service, validation_dir, target_dir)
         delete_directory_contents(self.os_service, validation_dir)
+
+    def move_sql_scripts_to_archive(self, version):
+        src = self.path_properties.next_sql_updates
+        dst = self.path_properties.archive_sql_updates
+        copytree_preserve_existing(self.os_service, src, dst)
+        delete_directory_contents(self.os_service, src)
 
     def copy_to_latest(self):
         source_dir = self.path_properties.next_validation_files

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -43,6 +43,10 @@ class AppPaths:
         return os.path.join(cand_dir, "production")
 
     @lazyprop
+    def production_config_lab_dir(self):
+        return os.path.join(self.production_dir, self.path_properties.config_lab_subpath)
+
+    @lazyprop
     def config_file_name(self):
         return "{}.exe.config".format(self.config["git_repo_name"])
 

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -51,7 +51,8 @@ class AppPaths:
         return "{}.exe.config".format(self.config["exe_file_name_base"])
 
     def move_candidates(self):
-        release_subdir = os.path.join(self.config["git_repo_name"], r'bin\release')
+        bin = os.path.join(self.config["project_root_dir"], 'bin')
+        release_subdir = os.path.join(bin, 'release')
         release_dir = os.path.join(self.download_dir, release_subdir)
         self.os_service.copytree(release_dir, self.validation_dir)
         self.os_service.copytree(release_dir, self.production_dir)
@@ -123,6 +124,7 @@ class Deployer:
         user_manual = self.path_properties.user_manual_download_path
         if not self.os_service.exists(user_manual):
             raise FileDoesNotExistsException(user_manual)
+
 
 class FileDoesNotExistsException(Exception):
     pass

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -62,7 +62,7 @@ class ValidationDeployer:
         self.path_properties = path_properties
         self.os_service = os_service
         self.path_actions = SnpseqPathActions(
-            whatif=False, snpseq_path_properties=self.path_properties,
+            whatif=False, path_properties=self.path_properties,
             os_service=self.os_service)
 
     def move_to_archive(self, version_in_latest):
@@ -93,3 +93,36 @@ class ValidationDeployer:
 
     def extract_version_from_path(self, path):
         return self.path_actions.find_version_from_candidate_path(path)
+
+
+class Deployer:
+    def __init__(self, path_properties, os_service, config, app_paths):
+        self.path_properties = path_properties
+        self.os_service = os_service
+        self.config = config
+        self.app_paths = app_paths
+
+    def check_exe_file_exists(self):
+        exe_filename = '{}.exe'.format(self.config['exe_file_name_base'])
+        exe = os.path.join(self.app_paths.production_dir, exe_filename)
+        if not self.os_service.exists(exe):
+            raise FileDoesNotExistsException(exe)
+
+    def check_config_file_exists(self):
+        config = os.path.join(self.app_paths.production_dir, self.app_paths.config_file_name)
+        if not self.os_service.exists(config):
+            raise FileDoesNotExistsException(config)
+
+    def check_config_lab_file_exists(self):
+        config_lab = os.path.join(
+            self.app_paths.production_config_lab_dir, self.app_paths.config_file_name)
+        if not self.os_service.exists(config_lab):
+            raise FileDoesNotExistsException(config_lab)
+
+    def check_user_manual_exists(self):
+        user_manual = self.path_properties.user_manual_download_path
+        if not self.os_service.exists(user_manual):
+            raise FileDoesNotExistsException(user_manual)
+
+class FileDoesNotExistsException(Exception):
+    pass

--- a/release_ccharp/apps/common/single_file_read_write.py
+++ b/release_ccharp/apps/common/single_file_read_write.py
@@ -33,7 +33,8 @@ class BinaryVersionUpdater:
 
     @lazyprop
     def assembly_file_path(self):
-        assembly_subpath = os.path.join(self.config["git_repo_name"], r'properties\assemblyinfo.cs')
+        properties = os.path.join(self.config["project_root_dir"], 'properties')
+        assembly_subpath = os.path.join(properties, 'assemblyinfo.cs')
         assembly_file_path = os.path.join(
             self.app_paths.download_dir, assembly_subpath)
         if not self.os_service.exists(assembly_file_path):

--- a/release_ccharp/apps/dev_environment.py
+++ b/release_ccharp/apps/dev_environment.py
@@ -12,10 +12,10 @@ class TestEnvironmentProvider:
 
     def generate(self, config):
         # Prepare
-        path_properites = SnpseqPathProperties(config, config["git_repo_name"])
+        path_properites = SnpseqPathProperties(config, config["git_repo_name"], OsService())
         path_actions = SnpseqPathActions(whatif=False, path_properties=path_properites,
                                          os_service=OsService())
-        wf = SnpseqWorkflow(whatif=False, repo=config["git_repo_name"])
+        wf = SnpseqWorkflow(whatif=False, repo=config["git_repo_name"], os_service=OsService())
         wf.config = config
         branch = "master"
         cand_path = os.path.join(path_properites.root_candidates, self.candidate_folder)

--- a/release_ccharp/apps/dev_environment.py
+++ b/release_ccharp/apps/dev_environment.py
@@ -13,7 +13,7 @@ class TestEnvironmentProvider:
     def generate(self, config):
         # Prepare
         path_properites = SnpseqPathProperties(config, config["git_repo_name"])
-        path_actions = SnpseqPathActions(whatif=False, snpseq_path_properties=path_properites,
+        path_actions = SnpseqPathActions(whatif=False, path_properties=path_properites,
                                          os_service=OsService())
         wf = SnpseqWorkflow(whatif=False, repo=config["git_repo_name"])
         wf.config = config

--- a/release_ccharp/apps/testing_repo.py
+++ b/release_ccharp/apps/testing_repo.py
@@ -4,6 +4,7 @@ from release_ccharp.apps.common.base import ApplicationBase
 from release_ccharp.apps.common.directory_handling import ValidationDeployer
 from release_ccharp.apps.chiasma_scripts.builder import ChiasmaBuilder
 from release_ccharp.apps.chiasma_scripts.validation_deployer import ChiasmaValidationDeployer
+from release_ccharp.snpseq_paths import SnpseqPathActions
 
 
 class Application(ApplicationBase):
@@ -18,7 +19,10 @@ class Application(ApplicationBase):
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         self.chiasma_builder = ChiasmaBuilder(self)
         common_validation_deployer = ValidationDeployer(self.path_properties, self.os_service)
-        self.validation_deployer = ChiasmaValidationDeployer(self, common_validation_deployer)
+        path_actions = SnpseqPathActions(
+            whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
+        self.validation_deployer = ChiasmaValidationDeployer(
+            self, common_validation_deployer, path_actions)
 
     def build(self):
         self.chiasma_builder.run()

--- a/release_ccharp/apps/testing_repo.py
+++ b/release_ccharp/apps/testing_repo.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from release_ccharp.apps.common.single_file_read_write import BinaryVersionUpdater
 from release_ccharp.apps.common.base import ApplicationBase
-from release_ccharp.apps.common.directory_handling import ValidationDeployer
+from release_ccharp.apps.common.directory_handling import FileDeployer
 from release_ccharp.apps.chiasma_scripts.builder import ChiasmaBuilder
 from release_ccharp.apps.chiasma_scripts.validation_deployer import ChiasmaValidationDeployer
 from release_ccharp.snpseq_paths import SnpseqPathActions
@@ -18,11 +18,12 @@ class Application(ApplicationBase):
             whatif=False, config=self.config, path_properties=self.path_properties,
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         self.chiasma_builder = ChiasmaBuilder(self)
-        common_validation_deployer = ValidationDeployer(self.path_properties, self.os_service)
+        file_deployer = FileDeployer(
+            self.path_properties, self.os_service, snpseq_workflow.config, self.app_paths)
         path_actions = SnpseqPathActions(
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
         self.validation_deployer = ChiasmaValidationDeployer(
-            self, common_validation_deployer, path_actions)
+            self, file_deployer, path_actions)
 
     def build(self):
         self.chiasma_builder.run()

--- a/release_ccharp/apps/testing_repo.py
+++ b/release_ccharp/apps/testing_repo.py
@@ -4,6 +4,7 @@ from release_ccharp.apps.common.base import ApplicationBase
 from release_ccharp.apps.common.directory_handling import FileDeployer
 from release_ccharp.apps.chiasma_scripts.builder import ChiasmaBuilder
 from release_ccharp.apps.chiasma_scripts.validation_deployer import ChiasmaValidationDeployer
+from release_ccharp.apps.chiasma_scripts.deployer import ChiasmaDeployer
 from release_ccharp.snpseq_paths import SnpseqPathActions
 
 
@@ -24,9 +25,22 @@ class Application(ApplicationBase):
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
         self.validation_deployer = ChiasmaValidationDeployer(
             self, file_deployer, path_actions)
+        self.deployer = ChiasmaDeployer(
+            self.path_properties, file_deployer, path_actions, os_service, branch_provider)
 
     def build(self):
+        super(Application, self).build()
         self.chiasma_builder.run()
 
     def deploy_validation(self):
+        super(Application, self).deploy_validation()
         self.validation_deployer.run()
+
+    def deploy(self):
+        super(Application, self).deploy()
+        self.deployer.run()
+
+    def download_release_history(self):
+        super(Application, self).download_release_history()
+        self.snpseq_workflow.download_release_history()
+        self.deployer.copy_release_history()

--- a/release_ccharp/cli.py
+++ b/release_ccharp/cli.py
@@ -104,7 +104,7 @@ def generate_folder_tree(ctx, repo):
     config = c.open_config(repo)
     path_properites = SnpseqPathProperties(config, repo)
     path_actions = SnpseqPathActions(whatif=ctx.obj['whatif'],
-                                     snpseq_path_properties=path_properites,
+                                     path_properties=path_properites,
                                      os_service=OsService())
     path_actions.generate_folder_tree()
 

--- a/release_ccharp/cli.py
+++ b/release_ccharp/cli.py
@@ -79,7 +79,7 @@ def deploy(ctx, repo):
 @click.pass_context
 def download_release_history(ctx, repo):
     factory = ApplicationFactory()
-    instance = factory.get_instance(whatif=ctx.ob['whatif'], repo=repo)
+    instance = factory.get_instance(whatif=ctx.obj['whatif'], repo=repo)
     instance.download_release_history()
 
 

--- a/release_ccharp/cli.py
+++ b/release_ccharp/cli.py
@@ -19,7 +19,7 @@ def cli(ctx, whatif):
 @click.option("--major", is_flag=True, default=False)
 @click.pass_context
 def create_cand(ctx, repo, major):
-    workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo)
+    workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo, os_service=OsService())
     workflow.create_cand(major_inc=major)
 
 
@@ -27,7 +27,7 @@ def create_cand(ctx, repo, major):
 @click.argument("repo")
 @click.pass_context
 def create_hotfix(ctx, repo):
-    workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo)
+    workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo, os_service=OsService())
     workflow.create_hotfix()
 
 
@@ -35,7 +35,7 @@ def create_hotfix(ctx, repo):
 @click.argument("repo")
 @click.pass_context
 def download(ctx, repo):
-    workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo)
+    workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo, os_service=OsService())
     workflow.download()
 
 
@@ -61,7 +61,7 @@ def deploy_validation(ctx, repo):
 @click.argument("repo")
 @click.pass_context
 def accept(ctx, repo):
-    workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo)
+    workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo, os_service=OsService())
     workflow.accept()
 
 
@@ -87,7 +87,7 @@ def download_release_history(ctx, repo):
 @click.option("--copy-latest", is_flag=True, default=False)
 @click.pass_context
 def generate_user_manual(ctx, repo, copy_latest):
-    workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo)
+    workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo, os_service=OsService())
     if copy_latest:
         print("Copy user manual from latest accepted directory")
         workflow.copy_previous_user_manual()
@@ -102,7 +102,7 @@ def generate_user_manual(ctx, repo, copy_latest):
 def generate_folder_tree(ctx, repo):
     c = Config()
     config = c.open_config(repo)
-    path_properites = SnpseqPathProperties(config, repo)
+    path_properites = SnpseqPathProperties(config, repo, OsService())
     path_actions = SnpseqPathActions(whatif=ctx.obj['whatif'],
                                      path_properties=path_properites,
                                      os_service=OsService())

--- a/release_ccharp/cli.py
+++ b/release_ccharp/cli.py
@@ -3,7 +3,7 @@ from release_ccharp.snpseq_workflow import SnpseqWorkflow
 from release_ccharp.snpseq_paths import SnpseqPathProperties
 from release_ccharp.snpseq_paths import SnpseqPathActions
 from release_ccharp.config import Config
-from release_ccharp.apps.common_xxx import ApplicationFactory
+from release_ccharp.apps.common.base import ApplicationFactory
 from release_ccharp.utility.os_service import OsService
 
 

--- a/release_ccharp/cli.py
+++ b/release_ccharp/cli.py
@@ -78,8 +78,9 @@ def deploy(ctx, repo):
 @click.argument("repo")
 @click.pass_context
 def download_release_history(ctx, repo):
-    workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo)
-    workflow.download_release_history()
+    factory = ApplicationFactory()
+    instance = factory.get_instance(whatif=ctx.ob['whatif'], repo=repo)
+    instance.download_release_history()
 
 
 @cli.command("generate-user-manual")

--- a/release_ccharp/cli.py
+++ b/release_ccharp/cli.py
@@ -109,6 +109,13 @@ def generate_folder_tree(ctx, repo):
                                      os_service=OsService())
     path_actions.generate_folder_tree()
 
+@cli.command("status")
+@click.argument("repo")
+@click.pass_context
+def status(ctx, repo):
+    wf = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo, os_service=OsService())
+    wf.status()
+
 def cli_main():
     cli(obj={})
 

--- a/release_ccharp/cli.py
+++ b/release_ccharp/cli.py
@@ -51,7 +51,7 @@ def build(ctx, repo):
 @cli.command("deploy-validation")
 @click.argument("repo")
 @click.pass_context
-def build(ctx, repo):
+def deploy_validation(ctx, repo):
     factory = ApplicationFactory()
     instance = factory.get_instance(whatif=ctx.obj['whatif'], repo=repo)
     instance.deploy_validation()
@@ -63,6 +63,15 @@ def build(ctx, repo):
 def accept(ctx, repo):
     workflow = SnpseqWorkflow(whatif=ctx.obj['whatif'], repo=repo)
     workflow.accept()
+
+
+@cli.command("deploy")
+@click.argument("repo")
+@click.pass_context
+def deploy(ctx, repo):
+    factory = ApplicationFactory()
+    instance = factory.get_instance(whatif=ctx.obj['whatif'], repo=repo)
+    instance.deploy()
 
 
 @cli.command("download-release-history")

--- a/release_ccharp/paths.config
+++ b/release_ccharp/paths.config
@@ -2,6 +2,7 @@ build_config_subpath : buildconfig
 release_tools_subpath : buildconfig\release-tools.config
 confluence_tools_subpath : buildconfig\confluence-tools.config
 candidate_subpath : candidates
+config_lab_subpath : Config_lab
 devel_environment_subpath : devel_environment
 doc_subpath : doc
 doc_metadata_subpath : metadata

--- a/release_ccharp/repo.config
+++ b/release_ccharp/repo.config
@@ -5,6 +5,7 @@ chiasma :
     project_root_dir : Chiasma
     confluence_space_key : DOCCHI
     owner : Molmed
+    deploy_root_path : L:\Labsystem\Chiasma\Installation\Klient\Chiasma\Filer
 testing-repo :
     root_path : C:\Tmp
     git_repo_name : testing-repo
@@ -12,9 +13,11 @@ testing-repo :
     project_root_dir : Chiasma
     confluence_space_key : CHI
     owner : GitEdvard
+    deploy_root_path : C:\Tmp\testing-repo-deploy
 order :
     root_path : P:\lims
     git_repo_name : PlattformOrdMan
     exe_file_name_base : Order
     project_root_dir : PlattformOrdMan
     owner : Molmed
+    deploy_root_path : L:\Labsystem\Chiasma\Installation\Klient\Order\Filer

--- a/release_ccharp/repo.config
+++ b/release_ccharp/repo.config
@@ -2,16 +2,19 @@ chiasma :
     root_path : P:\lims
     git_repo_name : chiasma
     exe_file_name_base : Chiasma
+    project_root_dir : Chiasma
     confluence_space_key : DOCCHI
     owner : Molmed
 testing-repo :
     root_path : C:\Tmp
     git_repo_name : testing-repo
-    exe_file_name_base : Chisama
+    exe_file_name_base : Chiasma
+    project_root_dir : Chiasma
     confluence_space_key : CHI
     owner : GitEdvard
 order :
     root_path : P:\lims
     git_repo_name : PlattformOrdMan
     exe_file_name_base : Order
+    project_root_dir : PlattformOrdMan
     owner : Molmed

--- a/release_ccharp/repo.config
+++ b/release_ccharp/repo.config
@@ -1,14 +1,17 @@
 chiasma :
     root_path : P:\lims
     git_repo_name : chiasma
+    exe_file_name_base : Chiasma
     confluence_space_key : DOCCHI
     owner : Molmed
 testing-repo :
     root_path : C:\Tmp
     git_repo_name : testing-repo
+    exe_file_name_base : Chisama
     confluence_space_key : CHI
     owner : GitEdvard
 order :
     root_path : P:\lims
     git_repo_name : PlattformOrdMan
+    exe_file_name_base : Order
     owner : Molmed

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -4,6 +4,7 @@ import yaml
 from release_ccharp.exceptions import SnpseqReleaseException
 from release_tools.workflow import Conventions
 from release_ccharp.utils import create_dirs
+from release_ccharp.utils import lazyprop
 
 
 class SnpseqPathProperties:
@@ -158,31 +159,38 @@ class SnpseqPathProperties:
         archive_version_dir = os.path.join(self.all_versions, str(self.branch_provider.candidate_version))
         return os.path.join(archive_version_dir, self.user_validations_validation_files_subpath)
 
+    @lazyprop
+    def shortcut_path(self):
+        filename = '{}.lnk'.format(self.config['exe_file_name_base'])
+        return os.path.join(self.user_validations_latest, filename)
+
 
 class SnpseqPathActions:
-    def __init__(self, whatif, snpseq_path_properties, os_service):
-        self.snpseq_path_properties = snpseq_path_properties
+    def __init__(self, whatif, path_properties, os_service, app_paths=None, windows_commands=None):
+        self.path_properties = path_properties
         self.whatif = whatif
         self.os_service = os_service
+        self.app_paths = app_paths
+        self.windows_commands = windows_commands
 
     def generate_folder_tree(self):
-        root_path = self.snpseq_path_properties._repo_root
+        root_path = self.path_properties._repo_root
         # Generate path variables
-        build_config = os.path.join(root_path, self.snpseq_path_properties.build_config_subpath)
-        candidates = os.path.join(root_path, self.snpseq_path_properties.candidate_subpath)
-        devel_environment = os.path.join(root_path, self.snpseq_path_properties.devel_environment_subpath)
-        doc = os.path.join(root_path, self.snpseq_path_properties.doc_subpath)
-        doc_metadata = os.path.join(doc, self.snpseq_path_properties.doc_metadata_subpath)
-        user_validations = os.path.join(root_path, self.snpseq_path_properties.user_validations_subpath)
-        user_validations_latest = os.path.join(user_validations, self.snpseq_path_properties.user_validations_latest_subpath)
-        latest_validation_files = os.path.join(user_validations_latest, self.snpseq_path_properties.user_validations_validation_files_subpath)
-        all_versions = os.path.join(user_validations, self.snpseq_path_properties.user_validations_all_version_subpath)
-        next_hotfix = os.path.join(all_versions, self.snpseq_path_properties.user_validations_next_hotfix_subpath)
-        next_release = os.path.join(all_versions, self.snpseq_path_properties.user_validations_next_release_subpath)
-        validation_files_next_hotfix = os.path.join(next_hotfix, self.snpseq_path_properties.user_validations_validation_files_subpath)
-        sql_updates_next_hotfix = os.path.join(next_hotfix, self.snpseq_path_properties.user_validations_sql_updates_subpath)
-        validation_files_next_release = os.path.join(next_release, self.snpseq_path_properties.user_validations_validation_files_subpath)
-        sql_updates_next_release = os.path.join(next_release, self.snpseq_path_properties.user_validations_sql_updates_subpath)
+        build_config = os.path.join(root_path, self.path_properties.build_config_subpath)
+        candidates = os.path.join(root_path, self.path_properties.candidate_subpath)
+        devel_environment = os.path.join(root_path, self.path_properties.devel_environment_subpath)
+        doc = os.path.join(root_path, self.path_properties.doc_subpath)
+        doc_metadata = os.path.join(doc, self.path_properties.doc_metadata_subpath)
+        user_validations = os.path.join(root_path, self.path_properties.user_validations_subpath)
+        user_validations_latest = os.path.join(user_validations, self.path_properties.user_validations_latest_subpath)
+        latest_validation_files = os.path.join(user_validations_latest, self.path_properties.user_validations_validation_files_subpath)
+        all_versions = os.path.join(user_validations, self.path_properties.user_validations_all_version_subpath)
+        next_hotfix = os.path.join(all_versions, self.path_properties.user_validations_next_hotfix_subpath)
+        next_release = os.path.join(all_versions, self.path_properties.user_validations_next_release_subpath)
+        validation_files_next_hotfix = os.path.join(next_hotfix, self.path_properties.user_validations_validation_files_subpath)
+        sql_updates_next_hotfix = os.path.join(next_hotfix, self.path_properties.user_validations_sql_updates_subpath)
+        validation_files_next_release = os.path.join(next_release, self.path_properties.user_validations_validation_files_subpath)
+        sql_updates_next_release = os.path.join(next_release, self.path_properties.user_validations_sql_updates_subpath)
         # Create paths
         self.create_dirs(build_config)
         self.create_dirs(candidates)
@@ -207,3 +215,10 @@ class SnpseqPathActions:
         res = re.match(r'.*(release|hotfix)-(\d+)\.(\d+)\.(\d+).*', candidate_path)
         version = '{}.{}.{}'.format(res.group(2), res.group(3), res.group(4))
         return version
+
+    def create_shortcut_to_exe(self):
+        exe_filename = '{}.exe'.format(self.path_properties.config['exe_file_name_base'])
+        shortcut_target = os.path.join(self.app_paths.validation_dir, exe_filename)
+        self.windows_commands.create_shortcut(
+            self.path_properties.shortcut_path, shortcut_target)
+

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -102,6 +102,11 @@ class SnpseqPathProperties:
         return subdir_path
 
     @property
+    def latest_accepted_release_history(self):
+        latest_path = self.latest_accepted_candidate_dir
+        return os.path.join(latest_path, "release-history.txt")
+
+    @property
     def current_candidate_dir(self):
         """
         Find the download catalog for the latest candidate branch

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -16,6 +16,7 @@ class SnpseqPathProperties:
         self.release_tools_subpath = sub_paths['release_tools_subpath']
         self.confluence_tools_subpath = sub_paths['confluence_tools_subpath']
         self.candidate_subpath = sub_paths['candidate_subpath']
+        self.config_lab_subpath = sub_paths['config_lab_subpath']
         self.devel_environment_subpath = sub_paths['devel_environment_subpath']
         self.doc_subpath = sub_paths['doc_subpath']
         self.doc_metadata_subpath = sub_paths['doc_metadata_subpath']
@@ -99,7 +100,6 @@ class SnpseqPathProperties:
     def current_candidate_dir(self):
         """
         Find the download catalog for the latest candidate branch
-        :param workflow: 
         :return: The path of the latest candidate branch
         """
         return os.path.join(self.root_candidates, self.branch_provider.candidate_branch)

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -160,6 +160,17 @@ class SnpseqPathProperties:
         return os.path.join(self.user_validations_next_dir, self.user_validations_sql_updates_subpath)
 
     @property
+    def archive_sql_updates(self):
+        """
+        Archive matching the current candidate
+        ...\AllVersions\<candidate version>\SQLUpdates
+        :return:
+        """
+        archive_version_dir = os.path.join(self.all_versions, str(self.branch_provider.candidate_version))
+        return os.path.join(archive_version_dir, self.user_validations_sql_updates_subpath)
+
+
+    @property
     def latest_validation_files(self):
         return os.path.join(self.user_validations_latest, self.user_validations_validation_files_subpath)
 

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -69,11 +69,14 @@ class SnpseqPathProperties:
         i.e. the path to the download directory (not the doc path)
         :return: 
         """
-        version = str(self._candidate_tag)
         latest_path = self.current_candidate_dir
+        return os.path.join(latest_path, self.user_manual_name)
+
+    @property
+    def user_manual_name(self):
+        version = str(self._candidate_tag)
         manual_base_name = "{}-user-manual".format(self.repo)
-        manual_name = "{}-{}.pdf".format(manual_base_name, version)
-        return os.path.join(latest_path, manual_name)
+        return "{}-{}.pdf".format(manual_base_name, version)
 
     @property
     def user_manual_path_previous(self):
@@ -158,6 +161,10 @@ class SnpseqPathProperties:
     def archive_dir_validation_files(self):
         archive_version_dir = os.path.join(self.all_versions, str(self.branch_provider.candidate_version))
         return os.path.join(archive_version_dir, self.user_validations_validation_files_subpath)
+
+    @property
+    def docs(self):
+        return os.path.join(self._repo_root, self.doc_subpath)
 
     @lazyprop
     def shortcut_path(self):

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -207,6 +207,7 @@ class SnpseqPathActions:
         self.create_dirs(sql_updates_next_hotfix)
         self.create_dirs(validation_files_next_release)
         self.create_dirs(sql_updates_next_release)
+        self.create_dirs(self.path_properties.config['deploy_root_path'])
 
     def create_dirs(self, path):
         create_dirs(self.os_service, path, self.whatif, self.whatif)

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -8,9 +8,10 @@ from release_ccharp.utils import lazyprop
 
 
 class SnpseqPathProperties:
-    def __init__(self, config, repo):
+    def __init__(self, config, repo, os_service):
         self.config = config
         self.repo = repo
+        self.os_service = os_service
         self.branch_provider = None
         sub_paths = self._load_subpaths()
         self.build_config_subpath = sub_paths['build_config_subpath']
@@ -91,7 +92,7 @@ class SnpseqPathProperties:
         Find the download catalog for the latest accepted branch
         :return: The path of latest accepted branch
         """
-        subdirs = os.listdir(self.root_candidates)
+        subdirs = self.os_service.listdir(self.root_candidates)
         subdir_path = None
         for subdir in subdirs:
             if re.match('(release|hotfix)-{}'.format(self.branch_provider.latest_version), subdir):
@@ -163,7 +164,7 @@ class SnpseqPathProperties:
         return os.path.join(archive_version_dir, self.user_validations_validation_files_subpath)
 
     @property
-    def docs(self):
+    def doc(self):
         return os.path.join(self._repo_root, self.doc_subpath)
 
     @lazyprop

--- a/release_ccharp/snpseq_workflow.py
+++ b/release_ccharp/snpseq_workflow.py
@@ -57,9 +57,7 @@ class SnpseqWorkflow:
         updated on GitHub        
         :return: 
         """
-        latest_path = self.paths.latest_accepted_candidate_dir
-        path = os.path.join(latest_path, "release-history.txt")
-        self.workflow.download_release_history(path=path)
+        self.workflow.download_release_history(path=self.paths.latest_accepted_release_history)
 
     def generate_user_manual(self):
         space_key = self.config["confluence_space_key"]

--- a/release_ccharp/snpseq_workflow.py
+++ b/release_ccharp/snpseq_workflow.py
@@ -9,7 +9,6 @@ from release_ccharp.snpseq_paths import SnpseqPathProperties
 from release_ccharp.exceptions import SnpseqReleaseException
 from release_ccharp.config import Config
 from release_ccharp.branches import BranchProvider
-from release_ccharp.apps.common.directory_handling import Deployer
 
 
 class SnpseqWorkflow:

--- a/release_ccharp/snpseq_workflow.py
+++ b/release_ccharp/snpseq_workflow.py
@@ -77,3 +77,34 @@ class SnpseqWorkflow:
             raise SnpseqReleaseException("Previous user manual could not be found: {}".format(latest_manual))
         if not self.whatif:
             copyfile(latest_manual, next_manual)
+
+    def status(self):
+        branches = self.workflow.provider.get_branches()
+        branch_names = [branch["name"] for branch in branches]
+
+        queue = self.workflow.get_queue()
+
+        latest_version = self.workflow.get_latest_version()
+        next_version = self.workflow.get_candidate_version()
+        hotfix_version = self.workflow.get_hotfix_version()
+        print "Latest version: {}".format(latest_version)
+        print "  - Next release version would be: {}".format(next_version)
+        print "  - Next hotfix version would be: {}".format(hotfix_version)
+
+        # TODO: Report all release tags too
+
+        print ""
+        print "Branches:"
+        for branch in branch_names:
+            print "  {}{}".format(branch, " *" if (branch in queue) else "")
+
+        print ""
+        print "Queue:"
+        # TODO: Use cache for api calls when possible
+        for branch in queue:
+            pull_requests = len(self.workflow.provider.get_pull_requests(branch))
+            print "  {} (PRs={})".format(branch, pull_requests)
+
+        # TODO: Compare relevant branches
+        print ""
+

--- a/release_ccharp/snpseq_workflow.py
+++ b/release_ccharp/snpseq_workflow.py
@@ -9,18 +9,19 @@ from release_ccharp.snpseq_paths import SnpseqPathProperties
 from release_ccharp.exceptions import SnpseqReleaseException
 from release_ccharp.config import Config
 from release_ccharp.branches import BranchProvider
+from release_ccharp.apps.common.directory_handling import Deployer
 
 
 class SnpseqWorkflow:
     """
     Initializes a release-tools workflow to act on the github provider
     """
-    def __init__(self, whatif, repo):
+    def __init__(self, whatif, repo, os_service):
         conf = Config()
         self.config = conf.open_config(repo)
         self.whatif = whatif
         self.repo = repo
-        self.paths = SnpseqPathProperties(self.config, self.repo)
+        self.paths = SnpseqPathProperties(self.config, self.repo, os_service)
         self.workflow = self._create_workflow()
         self.paths.branch_provider = BranchProvider(self.workflow)
 

--- a/release_ccharp/utils.py
+++ b/release_ccharp/utils.py
@@ -45,24 +45,46 @@ def create_dirs(os_service, path, whatif=False, log=True):
 
 def copytree_preserve_existing(os_service, src, dst):
     """
-    Copy entire file tree from src to dst. If a file with the same name already exists 
-    in dst, don't overwrite it. If a directory already exists in dst, it's contents will be 
-    preserved, but there might be new files added into it. 
+    Copy entire file tree from src to dst. If a file with the same name already exists
+    in dst, don't overwrite it. If a directory already exists in dst, it's contents will be
+    preserved, but there might be new files added into it.
     :param os_service: From this framework (real or fake)
     :param src: Source directory. The top directory is not copied, only it's contents
     :param dst: Destination directory. If it doesn't exists, it will be created.
-    :return: 
+    :return:
     """
     oss = os_service
-    if not oss.exists(dst):
-        oss.makedirs(dst)
-    for d in oss.listdir(src):
-        dest_sub_path = os.path.join(dst, d)
-        source_sub_path = os.path.join(src, d)
-        if oss.isdir(source_sub_path):
-            copytree_preserve_existing(oss, source_sub_path, dest_sub_path)
-        elif not oss.exists(dest_sub_path):
-            oss.copyfile(source_sub_path, dest_sub_path)
+    helper = Helpers()
+    helper.copy_directory_tree(oss, src, dst)
+
+    file_it = FileIterator(os_service, src)
+    for file_sub_path in file_it:
+        source_file_path = os.path.join(src, file_sub_path)
+        dest_file_path = os.path.join(dst, file_sub_path)
+        if not oss.exists(dest_file_path):
+            oss.copyfile(source_file_path, dest_file_path)
+
+
+def copytree_replace_existing(os_service, src, dst):
+    """
+    Copy entire file tree from src to dst. If a file with the same name already exists
+    in dst, don't overwrite it. If a directory already exists in dst, it's contents will be
+    preserved, but there might be new files added into it.
+    :param os_service: From this framework (real or fake)
+    :param src: Source directory. The top directory is not copied, only it's contents
+    :param dst: Destination directory. If it doesn't exists, it will be created.
+    :return:
+    """
+    oss = os_service
+    helper = Helpers()
+    helper.copy_directory_tree(oss, src, dst)
+
+    file_it = FileIterator(oss, src)
+    for file_sub_path in file_it:
+        source_file_path = os.path.join(src, file_sub_path)
+        dest_file_path = os.path.join(dst, file_sub_path)
+        oss.copyfile(source_file_path, dest_file_path)
+
 
 def delete_directory_contents(os_service, folder):
     """
@@ -79,5 +101,84 @@ def delete_directory_contents(os_service, folder):
         elif oss.isdir(path):
             oss.rmtree(path)
 
+
 class UnexpectedLengthError(ValueError):
     pass
+
+
+class FileIterator:
+    """
+    Iterates files under the given root directory. Return subpaths for the files, anchored at root.
+    """
+    def __init__(self, os_service, root):
+        self.os_service = os_service
+        self.root = root
+
+    def __iter__(self):
+        return self._traverse(self.root)
+
+    def _traverse(self, dir):
+        oss = self.os_service
+        for d in oss.listdir(dir):
+            sub_directory_cand = os.path.join(dir, d)
+            if oss.isdir(sub_directory_cand):
+                for x in self._traverse(sub_directory_cand):
+                    yield x
+            else:
+                yield os.path.relpath(sub_directory_cand, self.root)
+
+
+class DirectoryIterator:
+    """
+    Iterates directories under the given root directory. Return subpaths for the directory, anchored at root
+    """
+    def __init__(self, os_service, root):
+        self.root = root
+        self.os_service = os_service
+
+    def __iter__(self):
+        return self._traverse(self.root)
+
+    def _traverse(self, dir):
+        oss = self.os_service
+        for d in oss.listdir(dir):
+            sub_directory_cand = os.path.join(dir, d)
+            if oss.isdir(sub_directory_cand):
+                yield os.path.relpath(sub_directory_cand, self.root)
+                for x in self._traverse(sub_directory_cand):
+                    yield x
+
+
+class Helpers:
+    def copy_directory_tree(self, os_service, src, dst):
+        oss = os_service
+        if not oss.exists(dst):
+            oss.makedirs(dst)
+        dir_it = DirectoryIterator(oss, src)
+        for sub_dir in dir_it:
+            dest_dir = os.path.join(dst, sub_dir)
+            if not oss.exists(dest_dir):
+                oss.makedirs(dest_dir)
+
+
+class TestIterator:
+    def __init__(self):
+        self.current = 1
+
+    def create_generator(self):
+        while self.current < 5:
+            yield self.current
+            self.current += 1
+
+    def gen2(self):
+        for c in self._rec(0):
+            yield c
+
+    def _rec(self, depth):
+        if depth < 5:
+            yield depth
+            for x in self._rec(depth + 1):
+                yield x
+
+    def __iter__(self):
+        return self._rec(0)

--- a/tests/integration/chiasma_build_tests.py
+++ b/tests/integration/chiasma_build_tests.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import unittest
 from release_ccharp.apps.chiasma import Application
-from release_ccharp.apps.common_xxx import WindowsCommands
+from release_ccharp.apps.common.base import WindowsCommands
 from release_ccharp.snpseq_workflow import SnpseqWorkflow
 from release_ccharp.utility.os_service import OsService
 from release_ccharp.apps.dev_environment import TestEnvironmentProvider
@@ -16,7 +16,7 @@ class ChiasmaBuildTests(unittest.TestCase):
             "owner": "GitEdvard"
         }
         branch_provider = FakeBranchProvider()
-        wf = SnpseqWorkflow(whatif=False, repo="chiasma")
+        wf = SnpseqWorkflow(whatif=False, repo="chiasma", os_service=OsService())
         wf.config = config
         wf.paths.config = config
         wf.paths.branch_provider = branch_provider

--- a/tests/integration/chiasma_validation_deploy_tests.py
+++ b/tests/integration/chiasma_validation_deploy_tests.py
@@ -2,7 +2,7 @@ import unittest
 from unittest import skip
 from release_ccharp.snpseq_workflow import SnpseqWorkflow
 from release_ccharp.apps.chiasma import Application
-from release_ccharp.apps.common_xxx import WindowsCommands
+from release_ccharp.apps.common.base import WindowsCommands
 from release_ccharp.utility.os_service import OsService
 
 
@@ -11,11 +11,13 @@ class ChiasmaValidationDeployTests(unittest.TestCase):
         config = {
             "root_path": r'c:\tmp',
             "git_repo_name": "chiasma",
+            "exe_file_name_base": "Chiasma",
+            "project_root_dir" : "Chiasma",
             "confluence_space_key": "CHI",
             "owner": "GitEdvard"
         }
         branch_provider = FakeBranchProvider()
-        wf = SnpseqWorkflow(whatif=False, repo="chiasma")
+        wf = SnpseqWorkflow(whatif=False, repo="chiasma", os_service=OsService())
         wf.config = config
         wf.paths.config = config
         wf.paths.branch_provider = branch_provider

--- a/tests/integration/misc_tests.py
+++ b/tests/integration/misc_tests.py
@@ -3,11 +3,12 @@ import os
 import re
 import yaml
 from release_ccharp.snpseq_workflow import SnpseqWorkflow
+from release_ccharp.utility.os_service import OsService
 
 
 class MiscTests(unittest.TestCase):
     def setUp(self):
-        self.workflow = SnpseqWorkflow(whatif=False, repo='testing-repo')
+        self.workflow = SnpseqWorkflow(whatif=False, repo='testing-repo', os_service=OsService())
 
     @unittest.skip("")
     def test_yaml(self):

--- a/tests/integration/path_tests.py
+++ b/tests/integration/path_tests.py
@@ -3,13 +3,15 @@ from release_ccharp.snpseq_paths import SnpseqPathActions
 from release_ccharp.snpseq_paths import SnpseqPathProperties
 from release_ccharp.config import Config
 from release_ccharp.utility.os_service import OsService
+from tests.unit.utility.fake_os_service import FakeOsService
 
 
 class PathTests(unittest.TestCase):
 
     def setUp(self):
         conf = Config()
-        self.path_properties = SnpseqPathProperties(conf.open_config(repo='testing-repo'), repo='testing-repo')
+        self.path_properties = SnpseqPathProperties(
+            conf.open_config(repo='testing-repo'), repo='testing-repo', os_service=None)
 
     @unittest.skip("")
     def test_find_current_candidate_dir(self):

--- a/tests/integration/workflow_tests.py
+++ b/tests/integration/workflow_tests.py
@@ -1,11 +1,12 @@
 import unittest
 from release_ccharp.snpseq_workflow import SnpseqWorkflow
+from release_ccharp.utility.os_service import OsService
 
 
 class WorkflowTests(unittest.TestCase):
     def setUp(self):
         # pass
-        self.workflow = SnpseqWorkflow(whatif=False, repo='testing-repo')
+        self.workflow = SnpseqWorkflow(whatif=False, repo='testing-repo', os_service=OsService())
 
     @unittest.skip("")
     def test_create_cand(self):

--- a/tests/unit/app_path_tests.py
+++ b/tests/unit/app_path_tests.py
@@ -11,6 +11,7 @@ class AppPathTests(unittest.TestCase):
         config = {
             "root_path": r'c:\xxx',
             "git_repo_name": "chiasma",
+            "exe_file_name_base": "Chiasma",
             "confluence_space_key": "CHI",
             "owner": "GitEdvard"
         }
@@ -43,7 +44,7 @@ class AppPathTests(unittest.TestCase):
 
     def test_config_file_name__with_creation_by_convention__returns_correctly(self):
         name = self.app_paths.config_file_name
-        self.assertEqual("chiasma.exe.config", name)
+        self.assertEqual("Chiasma.exe.config", name)
 
     def test_move_candidates__with_one_file_added_in_bin_release__file_found_in_validation(self):
         self.app_paths.move_candidates()

--- a/tests/unit/app_path_tests.py
+++ b/tests/unit/app_path_tests.py
@@ -12,6 +12,7 @@ class AppPathTests(unittest.TestCase):
             "root_path": r'c:\xxx',
             "git_repo_name": "chiasma",
             "exe_file_name_base": "Chiasma",
+            "project_root_dir": "Chiasma",
             "confluence_space_key": "CHI",
             "owner": "GitEdvard"
         }

--- a/tests/unit/app_path_tests.py
+++ b/tests/unit/app_path_tests.py
@@ -21,7 +21,7 @@ class AppPathTests(unittest.TestCase):
                        r'\release\chiasma.exe')
         filesystem.CreateFile(chiasma_exe)
         branch_provider = FakeBranchProvider()
-        path_properties = SnpseqPathProperties(config, "chiasma")
+        path_properties = SnpseqPathProperties(config, "chiasma", None)
         path_properties.branch_provider = branch_provider
         os_service = FakeOsService(filesystem)
         self.os_module = os_service.os_module

--- a/tests/unit/application_factory_tests.py
+++ b/tests/unit/application_factory_tests.py
@@ -10,7 +10,11 @@ class ApplicationFactoryTests(unittest.TestCase):
     def test_initiate_chiasma(self):
         instance = self.factory.get_instance(False, "chiasma")
         self.assertTrue(getattr(instance, "build"))
+        self.assertTrue(getattr(instance, "deploy_validation"))
+        self.assertTrue(getattr(instance, "deploy"))
 
     def test_initiate_testing_repo(self):
         instance = self.factory.get_instance(False, "testing-repo")
         self.assertTrue(getattr(instance, "build"))
+        self.assertTrue(getattr(instance, "deploy_validation"))
+        self.assertTrue(getattr(instance, "deploy"))

--- a/tests/unit/chiasma_build_tests_unit.py
+++ b/tests/unit/chiasma_build_tests_unit.py
@@ -6,6 +6,7 @@ from pyfakefs.fake_filesystem import FakeFileOpen
 from release_ccharp.apps.chiasma import Application
 from release_ccharp.snpseq_workflow import SnpseqWorkflow
 from release_ccharp.apps.common.single_file_read_write import StandardVSConfigXML
+from release_ccharp.snpseq_paths import SnpseqPathActions
 from tests.unit.utility.fake_os_service import FakeOsService
 from tests.unit.utility.config import CHIASMA_CONFIG
 from tests.unit.utility.fake_windows_commands import FakeWindowsCommands
@@ -16,6 +17,7 @@ class ChiasmaBuildTests(unittest.TestCase):
         config = {
             "root_path": r'c:\xxx',
             "git_repo_name": "chiasma",
+            "exe_file_name_base": "Chiasma",
             "confluence_space_key": "CHI",
             "owner": "GitEdvard"
         }
@@ -35,6 +37,11 @@ class ChiasmaBuildTests(unittest.TestCase):
         self.os_module = os_service.os_module
         self.chiasma = Application(wf, branch_provider, os_service,
                                    FakeWindowsCommands(self.filesystem), whatif=False)
+        path_actions = SnpseqPathActions(
+            whatif=False, snpseq_path_properties=self.chiasma.path_properties,
+            os_service=os_service
+        )
+        path_actions.generate_folder_tree()
 
     def test__get_version(self):
         version = self.chiasma.branch_provider.candidate_version

--- a/tests/unit/chiasma_deploy_tests.py
+++ b/tests/unit/chiasma_deploy_tests.py
@@ -15,6 +15,7 @@ class ChiasmaDeployTests(unittest.TestCase):
         config = {
             "root_path": r'c:\xxx',
             "git_repo_name": "chiasma",
+            "exe_file_name_base": "Chiasma",
             "owner": "GitEdvard"
         }
         branch_provider = FakeBranchProvider()

--- a/tests/unit/chiasma_deploy_tests.py
+++ b/tests/unit/chiasma_deploy_tests.py
@@ -1,0 +1,104 @@
+import unittest
+import os
+from unittest import skip
+from pyfakefs import fake_filesystem
+from release_ccharp.snpseq_workflow import SnpseqWorkflow
+from release_ccharp.snpseq_paths import SnpseqPathActions
+from release_ccharp.apps.chiasma import Application
+from release_ccharp.apps.chiasma_scripts.deployer import FileDoesNotExistsException
+from tests.unit.utility.fake_os_service import FakeOsService
+from tests.unit.utility.fake_windows_commands import FakeWindowsCommands
+
+
+class ChiasmaDeployTests(unittest.TestCase):
+    def setUp(self):
+        config = {
+            "root_path": r'c:\xxx',
+            "git_repo_name": "chiasma",
+            "owner": "GitEdvard"
+        }
+        branch_provider = FakeBranchProvider()
+        wf = SnpseqWorkflow(whatif=False, repo="chiasma")
+        wf.config = config
+        wf.paths.config = config
+        wf.paths.branch_provider = branch_provider
+        self.filesystem = fake_filesystem.FakeFilesystem()
+        os_service = FakeOsService(self.filesystem)
+        self.os_module = os_service.os_module
+        self.chiasma = Application(wf, branch_provider, os_service,
+                                   FakeWindowsCommands(self.filesystem), whatif=False)
+        self.file_builder = FileSystemBuilder(self.chiasma, self.filesystem)
+
+        path_actions = SnpseqPathActions(
+            whatif=False, snpseq_path_properties=self.chiasma.path_properties,
+            os_service=os_service
+        )
+        path_actions.generate_folder_tree()
+
+    def test_check_source_files__with_exe_lacking__throws(self):
+        # Arrange
+        #self.file_builder.add_file_in_production('chiasma.exe')
+        self.file_builder.add_file_in_production('chiasma.exe.config')
+        self.file_builder.add_file_in_production_config_lab('chiasma.exe.config')
+        self.file_builder.add_file_in_current_candidate_dir('chiasma-user-manual-v1.0.0.pdf')
+        # Act
+        # Assert
+        with self.assertRaises(FileDoesNotExistsException):
+            self.chiasma.deployer.run()
+
+    def test_check_source_files__with_config_lacking__throws(self):
+        # Arrange
+        self.file_builder.add_file_in_production('chiasma.exe')
+        #self.file_builder.add_file_in_production('chiasma.exe.config')
+        self.file_builder.add_file_in_production_config_lab('chiasma.exe.config')
+        self.file_builder.add_file_in_current_candidate_dir('chiasma-user-manual-v1.0.0.pdf')
+        # Act
+        # Assert
+        with self.assertRaises(FileDoesNotExistsException):
+            self.chiasma.deployer.run()
+
+    def test_check_source_file__with_config_lab_lacking__throws(self):
+        # Arrange
+        self.file_builder.add_file_in_production('chiasma.exe')
+        self.file_builder.add_file_in_production('chiasma.exe.config')
+        # self.file_builder.add_file_in_production_config_lab('chiasma.exe.config')
+        self.file_builder.add_file_in_current_candidate_dir('chiasma-user-manual-v1.0.0.pdf')
+        # Act
+        # Assert
+        with self.assertRaises(FileDoesNotExistsException):
+            self.chiasma.deployer.run()
+
+    def test_check_source_file__with_user_manual_lacking__throws(self):
+        # Arrange
+        self.file_builder.add_file_in_production('chiasma.exe')
+        self.file_builder.add_file_in_production('chiasma.exe.config')
+        self.file_builder.add_file_in_production_config_lab('chiasma.exe.config')
+        #self.file_builder.add_file_in_current_candidate_dir('chiasma-user-manual-v1.0.0.pdf')
+        # Act
+        # Assert
+        with self.assertRaises(FileDoesNotExistsException):
+            self.chiasma.deployer.run()
+
+
+class FakeBranchProvider:
+    def __init__(self):
+        self.candidate_version = "1.0.0"
+        self.latest_version = "latest-version"
+        self.candidate_branch = "release-1.0.0"
+
+
+class FileSystemBuilder:
+    def __init__(self, chiasma, filesystem):
+        self.chiasma = chiasma
+        self.filesystem = filesystem
+
+    def add_file_in_production(self, filename='filename.txt'):
+        path = os.path.join(self.chiasma.app_paths.production_dir, filename)
+        self.filesystem.CreateFile(path)
+
+    def add_file_in_production_config_lab(self, filename='file.txt'):
+        path = os.path.join(self.chiasma.app_paths.production_config_lab_dir, filename)
+        self.filesystem.CreateFile(path)
+
+    def add_file_in_current_candidate_dir(self, filename='file.txt'):
+        path = os.path.join(self.chiasma.path_properties.current_candidate_dir, filename)

--- a/tests/unit/chiasma_tests/base.py
+++ b/tests/unit/chiasma_tests/base.py
@@ -4,6 +4,7 @@ from pyfakefs import fake_filesystem
 from release_ccharp.snpseq_workflow import SnpseqWorkflow
 from release_ccharp.snpseq_paths import SnpseqPathActions
 from release_ccharp.apps.chiasma import Application
+from release_ccharp.utils import create_dirs
 from tests.unit.utility.fake_os_service import FakeOsService
 from tests.unit.utility.fake_windows_commands import FakeWindowsCommands
 
@@ -19,13 +20,13 @@ class ChiasmaBaseTests(unittest.TestCase):
             "deploy_root_path": r'c:\xxx\deploy'
         }
         branch_provider = FakeBranchProvider()
-        wf = SnpseqWorkflow(whatif=False, repo="chiasma")
-        wf.config = config
-        wf.paths.config = config
-        wf.paths.branch_provider = branch_provider
         self.filesystem = fake_filesystem.FakeFilesystem()
         os_service = FakeOsService(self.filesystem)
         self.os_module = os_service.os_module
+        wf = SnpseqWorkflow(whatif=False, repo="chiasma", os_service=os_service)
+        wf.config = config
+        wf.paths.config = config
+        wf.paths.branch_provider = branch_provider
         self.chiasma = Application(wf, branch_provider, os_service,
                                    FakeWindowsCommands(self.filesystem), whatif=False)
 
@@ -34,6 +35,7 @@ class ChiasmaBaseTests(unittest.TestCase):
             os_service=os_service
         )
         path_actions.generate_folder_tree()
+        create_dirs(os_service, self.chiasma.path_properties.current_candidate_dir, False, False)
 
 
 class FakeBranchProvider:

--- a/tests/unit/chiasma_tests/base.py
+++ b/tests/unit/chiasma_tests/base.py
@@ -28,7 +28,7 @@ class ChiasmaBaseTests(unittest.TestCase):
                                    FakeWindowsCommands(self.filesystem), whatif=False)
 
         path_actions = SnpseqPathActions(
-            whatif=False, snpseq_path_properties=self.chiasma.path_properties,
+            whatif=False, path_properties=self.chiasma.path_properties,
             os_service=os_service
         )
         path_actions.generate_folder_tree()

--- a/tests/unit/chiasma_tests/base.py
+++ b/tests/unit/chiasma_tests/base.py
@@ -1,0 +1,41 @@
+import unittest
+import os
+from pyfakefs import fake_filesystem
+from release_ccharp.snpseq_workflow import SnpseqWorkflow
+from release_ccharp.snpseq_paths import SnpseqPathActions
+from release_ccharp.apps.chiasma import Application
+from tests.unit.utility.fake_os_service import FakeOsService
+from tests.unit.utility.fake_windows_commands import FakeWindowsCommands
+
+
+class ChiasmaBaseTests(unittest.TestCase):
+    def base_setup(self):
+        config = {
+            "root_path": r'c:\xxx',
+            "git_repo_name": "chiasma",
+            "exe_file_name_base": "Chiasma",
+            "owner": "GitEdvard"
+        }
+        branch_provider = FakeBranchProvider()
+        wf = SnpseqWorkflow(whatif=False, repo="chiasma")
+        wf.config = config
+        wf.paths.config = config
+        wf.paths.branch_provider = branch_provider
+        self.filesystem = fake_filesystem.FakeFilesystem()
+        os_service = FakeOsService(self.filesystem)
+        self.os_module = os_service.os_module
+        self.chiasma = Application(wf, branch_provider, os_service,
+                                   FakeWindowsCommands(self.filesystem), whatif=False)
+
+        path_actions = SnpseqPathActions(
+            whatif=False, snpseq_path_properties=self.chiasma.path_properties,
+            os_service=os_service
+        )
+        path_actions.generate_folder_tree()
+
+
+class FakeBranchProvider:
+    def __init__(self):
+        self.candidate_version = "1.0.0"
+        self.latest_version = "latest-version"
+        self.candidate_branch = "release-1.0.0"

--- a/tests/unit/chiasma_tests/base.py
+++ b/tests/unit/chiasma_tests/base.py
@@ -15,7 +15,8 @@ class ChiasmaBaseTests(unittest.TestCase):
             "git_repo_name": "chiasma",
             "exe_file_name_base": "Chiasma",
             "project_root_dir" : "Chiasma",
-            "owner": "GitEdvard"
+            "owner": "GitEdvard",
+            "deploy_root_path": r'c:\xxx\deploy'
         }
         branch_provider = FakeBranchProvider()
         wf = SnpseqWorkflow(whatif=False, repo="chiasma")

--- a/tests/unit/chiasma_tests/base.py
+++ b/tests/unit/chiasma_tests/base.py
@@ -36,10 +36,13 @@ class ChiasmaBaseTests(unittest.TestCase):
         )
         path_actions.generate_folder_tree()
         create_dirs(os_service, self.chiasma.path_properties.current_candidate_dir, False, False)
+        latest_candidate = 'release-{}'.format(branch_provider.latest_version)
+        latest_dir = os.path.join(self.chiasma.path_properties.root_candidates, latest_candidate)
+        create_dirs(os_service, latest_dir, False, False)
 
 
 class FakeBranchProvider:
     def __init__(self):
         self.candidate_version = "1.0.0"
-        self.latest_version = "latest-version"
+        self.latest_version = "0.0.9"
         self.candidate_branch = "release-1.0.0"

--- a/tests/unit/chiasma_tests/base.py
+++ b/tests/unit/chiasma_tests/base.py
@@ -14,6 +14,7 @@ class ChiasmaBaseTests(unittest.TestCase):
             "root_path": r'c:\xxx',
             "git_repo_name": "chiasma",
             "exe_file_name_base": "Chiasma",
+            "project_root_dir" : "Chiasma",
             "owner": "GitEdvard"
         }
         branch_provider = FakeBranchProvider()

--- a/tests/unit/chiasma_tests/chiasma_deploy_tests.py
+++ b/tests/unit/chiasma_tests/chiasma_deploy_tests.py
@@ -63,7 +63,7 @@ class ChiasmaDeployTests(ChiasmaBaseTests):
         # Arrange
         self.add_required_files()
         # Act
-        self.chiasma.deployer.common_deployer.move_deploy_files()
+        self.chiasma.deployer.file_deployer.move_deploy_files()
         # Assert
         exe_path = r'c:\xxx\deploy\chiasma.exe'
         standard_config = r'c:\xxx\deploy\chiasma.exe.config'
@@ -76,7 +76,7 @@ class ChiasmaDeployTests(ChiasmaBaseTests):
         # Arrange
         self.add_required_files()
         # Act
-        self.chiasma.deployer.common_deployer.move_user_manual()
+        self.chiasma.deployer.file_deployer.move_user_manual()
         # Assert
         user_manaul_path = r'c:\xxx\chiasma\doc\chiasma-user-manual-v1.0.0.pdf'
         self.assertTrue(self.os_module.path.exists(user_manaul_path))
@@ -86,10 +86,11 @@ class ChiasmaDeployTests(ChiasmaBaseTests):
         self.add_required_files()
         self.file_builder.add_file_in_latest_candidate_dir(r'release-history.txt')
         # Act
-        self.chiasma.deployer.common_deployer.copy_release_history()
+        self.chiasma.deployer.file_deployer.copy_release_history()
         # Assert
         release_history = r'c:\xxx\chiasma\doc\release-history.txt'
         self.assertTrue(self.os_module.path.exists(release_history))
+
 
 
 class FileSystemBuilder:
@@ -113,3 +114,8 @@ class FileSystemBuilder:
         path = os.path.join(self.chiasma.path_properties.latest_accepted_candidate_dir, filename)
         print('add file into: {}'.format(path))
         self.filesystem.CreateFile(path)
+
+    def add_validation_file_in_latest(self, filename='validationfile.txt', contents=''):
+        path = os.path.join(self.chiasma.path_properties.latest_validation_files, filename)
+        self.filesystem.CreateFile(path, contents=contents)
+

--- a/tests/unit/chiasma_tests/chiasma_deploy_tests.py
+++ b/tests/unit/chiasma_tests/chiasma_deploy_tests.py
@@ -9,6 +9,12 @@ class ChiasmaDeployTests(ChiasmaBaseTests):
         self.base_setup()
         self.file_builder = FileSystemBuilder(self.chiasma, self.filesystem)
 
+    def add_required_files(self):
+        self.file_builder.add_file_in_production('chiasma.exe')
+        self.file_builder.add_file_in_production('chiasma.exe.config')
+        self.file_builder.add_file_in_production_config_lab('chiasma.exe.config')
+        self.file_builder.add_file_in_current_candidate_dir('chiasma-user-manual-v1.0.0.pdf')
+
     def test_check_source_files__with_exe_lacking__throws(self):
         # Arrange
         #self.file_builder.add_file_in_production('chiasma.exe')
@@ -53,6 +59,20 @@ class ChiasmaDeployTests(ChiasmaBaseTests):
         with self.assertRaises(FileDoesNotExistsException):
             self.chiasma.deployer.run()
 
+    def test_move_files__with_three_files_in_production__files_exists_in_deploy_catalog(self):
+        # Arrange
+        self.add_required_files()
+        # Act
+        self.chiasma.deployer.run()
+        # Assert
+        exe_path = r'c:\xxx\deploy\chiasma.exe'
+        standard_config = r'c:\xxx\deploy\chiasma.exe.config'
+        lab_config = r'c:\xxx\deploy\Config_lab\chiasma.exe.config'
+        self.assertTrue(self.os_module.path.exists(exe_path))
+        self.assertTrue(self.os_module.path.exists(standard_config))
+        self.assertTrue(self.os_module.path.exists(lab_config))
+
+
 
 class FileSystemBuilder:
     def __init__(self, chiasma, filesystem):
@@ -69,3 +89,4 @@ class FileSystemBuilder:
 
     def add_file_in_current_candidate_dir(self, filename='file.txt'):
         path = os.path.join(self.chiasma.path_properties.current_candidate_dir, filename)
+        self.filesystem.CreateFile(path)

--- a/tests/unit/chiasma_tests/chiasma_deploy_tests.py
+++ b/tests/unit/chiasma_tests/chiasma_deploy_tests.py
@@ -1,40 +1,13 @@
-import unittest
 import os
 from unittest import skip
-from pyfakefs import fake_filesystem
-from release_ccharp.snpseq_workflow import SnpseqWorkflow
-from release_ccharp.snpseq_paths import SnpseqPathActions
-from release_ccharp.apps.chiasma import Application
 from release_ccharp.apps.chiasma_scripts.deployer import FileDoesNotExistsException
-from tests.unit.utility.fake_os_service import FakeOsService
-from tests.unit.utility.fake_windows_commands import FakeWindowsCommands
+from tests.unit.chiasma_tests.base import ChiasmaBaseTests
 
 
-class ChiasmaDeployTests(unittest.TestCase):
+class ChiasmaDeployTests(ChiasmaBaseTests):
     def setUp(self):
-        config = {
-            "root_path": r'c:\xxx',
-            "git_repo_name": "chiasma",
-            "exe_file_name_base": "Chiasma",
-            "owner": "GitEdvard"
-        }
-        branch_provider = FakeBranchProvider()
-        wf = SnpseqWorkflow(whatif=False, repo="chiasma")
-        wf.config = config
-        wf.paths.config = config
-        wf.paths.branch_provider = branch_provider
-        self.filesystem = fake_filesystem.FakeFilesystem()
-        os_service = FakeOsService(self.filesystem)
-        self.os_module = os_service.os_module
-        self.chiasma = Application(wf, branch_provider, os_service,
-                                   FakeWindowsCommands(self.filesystem), whatif=False)
+        self.base_setup()
         self.file_builder = FileSystemBuilder(self.chiasma, self.filesystem)
-
-        path_actions = SnpseqPathActions(
-            whatif=False, snpseq_path_properties=self.chiasma.path_properties,
-            os_service=os_service
-        )
-        path_actions.generate_folder_tree()
 
     def test_check_source_files__with_exe_lacking__throws(self):
         # Arrange
@@ -79,13 +52,6 @@ class ChiasmaDeployTests(unittest.TestCase):
         # Assert
         with self.assertRaises(FileDoesNotExistsException):
             self.chiasma.deployer.run()
-
-
-class FakeBranchProvider:
-    def __init__(self):
-        self.candidate_version = "1.0.0"
-        self.latest_version = "latest-version"
-        self.candidate_branch = "release-1.0.0"
 
 
 class FileSystemBuilder:

--- a/tests/unit/chiasma_tests/chiasma_deploy_tests.py
+++ b/tests/unit/chiasma_tests/chiasma_deploy_tests.py
@@ -63,7 +63,7 @@ class ChiasmaDeployTests(ChiasmaBaseTests):
         # Arrange
         self.add_required_files()
         # Act
-        self.chiasma.deployer.run()
+        self.chiasma.deployer.common_deployer.move_deploy_files()
         # Assert
         exe_path = r'c:\xxx\deploy\chiasma.exe'
         standard_config = r'c:\xxx\deploy\chiasma.exe.config'
@@ -71,6 +71,16 @@ class ChiasmaDeployTests(ChiasmaBaseTests):
         self.assertTrue(self.os_module.path.exists(exe_path))
         self.assertTrue(self.os_module.path.exists(standard_config))
         self.assertTrue(self.os_module.path.exists(lab_config))
+
+    def test_move_user_manual__user_manual_existent__user_manual_moved_to_docs(self):
+        # Arrange
+        self.add_required_files()
+        # Act
+        self.chiasma.deployer.common_deployer.move_user_manual()
+        # Assert
+        user_manaul_path = r'c:\xxx\chiasma\doc\chiasma-user-manual-v1.0.0.pdf'
+        self.assertTrue(self.os_module.path.exists(user_manaul_path))
+
 
 
 

--- a/tests/unit/chiasma_tests/chiasma_deploy_tests.py
+++ b/tests/unit/chiasma_tests/chiasma_deploy_tests.py
@@ -91,6 +91,109 @@ class ChiasmaDeployTests(ChiasmaBaseTests):
         release_history = r'c:\xxx\chiasma\doc\release-history.txt'
         self.assertTrue(self.os_module.path.exists(release_history))
 
+    def test_archive_version__with_validation_files_and_sql_script__validation_file_in_archive_folder(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        # Act
+        self.chiasma.deployer.move_to_archive()
+        # Assert
+        archived_validation_file = \
+            r'c:\xxx\chiasma\uservalidations\allversions\1.0.0\validationfiles\validationfile.txt'
+        self.assertTrue(self.os_module.path.exists(archived_validation_file))
+
+    def test_archive_version__with_validation_files_and_sql_script__validation_files_removed_from_latest(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        # Act
+        self.chiasma.deployer.move_to_archive()
+        # Assert
+        validation_dir_in_latest = \
+            r'c:\xxx\chiasma\uservalidations\latest\validationfiles'
+        self.assertFalse(self.os_module.path.exists(validation_dir_in_latest))
+
+    def test_archive_version__with_validation_files_and_sql_script__validation_file_removed_from_next(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_validation_file_in_next(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        # Act
+        self.chiasma.deployer.move_to_archive()
+        # Assert
+        path_to_validation_in_next = \
+            r'c:\xxx\chiasma\uservalidations\allversions\_next_release\validationfiles\validationfile.txt'
+        self.assertFalse(self.os_module.path.exists(path_to_validation_in_next))
+
+    def test_archive_version__with_validation_files_and_sql_script__shortcut_in_archive_folder(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        # Act
+        self.chiasma.deployer.move_to_archive()
+        # Assert
+        archived_shortcut = \
+            r'c:\xxx\chiasma\uservalidations\allversions\1.0.0\chiasma.lnk'
+        self.assertTrue(self.os_module.path.exists(archived_shortcut))
+
+    def test_archive_version__with_validation_files_and_sql_script__shortcut_remains_in_latest(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        # Act
+        self.chiasma.deployer.move_to_archive()
+        # Assert
+        shortcut_in_latest = \
+            r'c:\xxx\chiasma\uservalidations\latest\chiasma.lnk'
+        self.assertTrue(self.os_module.path.exists(shortcut_in_latest))
+
+    def test_archive_version__with_validation_files_and_sql_script__shortcut_target_correct_in_latest(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        # Act
+        self.chiasma.deployer.move_to_archive()
+        # Assert
+        shortcut_in_latest = \
+            r'c:\xxx\chiasma\uservalidations\latest\chiasma.lnk'
+        shortcut_target = self.chiasma.validation_deployer.shortcut_examiner.\
+            _extract_shortcut_target(shortcut_in_latest)
+        self.assertEqual(r'c:\xxx\chiasma\candidates\release-1.0.0\validation\Chiasma.exe', shortcut_target)
+
+    def test_archive_version__with_validation_files_and_sql_script__sql_script_in_archive_folder(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        # Act
+        self.chiasma.deployer.move_to_archive()
+        # Assert
+        archived_script = \
+            r'c:\xxx\chiasma\uservalidations\allversions\1.0.0\sqlupdates\script1.sql'
+        self.assertTrue(self.os_module.path.exists(archived_script))
+
+    def test_archive_version__with_validation_files_and_sql_script__sql_script_removed_from_next(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        # Act
+        self.chiasma.deployer.move_to_archive()
+        # Assert
+        script_path_in_next = \
+            r'c:\xxx\chiasma\uservalidations\allversions\_next_release\sqlupdates\script1.sql'
+        self.assertFalse(self.os_module.path.exists(script_path_in_next))
 
 
 class FileSystemBuilder:
@@ -119,3 +222,18 @@ class FileSystemBuilder:
         path = os.path.join(self.chiasma.path_properties.latest_validation_files, filename)
         self.filesystem.CreateFile(path, contents=contents)
 
+    def add_validation_file_in_next(self, filename='validationfile.txt', contents=''):
+        path = os.path.join(self.chiasma.path_properties.next_validation_files, filename)
+        print('add file into: {}'.format(path))
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def add_sql_script_in_next(self, filename='script1.sql', contents=''):
+        path = os.path.join(self.chiasma.path_properties.next_sql_updates, filename)
+        print('add file into: {}'.format(path))
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def add_shortcut(self, candidate_dir='release-1.0.0'):
+        cand_path = os.path.join(self.chiasma.path_properties.root_candidates, candidate_dir)
+        current_shortcut_target = os.path.join(cand_path, r'buildpath\chiasma.exe')
+        shortcut_save_path = os.path.join(self.chiasma.path_properties.user_validations_latest, r'chiasma.lnk')
+        self.chiasma.windows_commands.create_shortcut(shortcut_save_path, current_shortcut_target)

--- a/tests/unit/chiasma_tests/chiasma_deploy_tests.py
+++ b/tests/unit/chiasma_tests/chiasma_deploy_tests.py
@@ -1,6 +1,6 @@
 import os
 from unittest import skip
-from release_ccharp.apps.chiasma_scripts.deployer import FileDoesNotExistsException
+from release_ccharp.apps.common.directory_handling import FileDoesNotExistsException
 from tests.unit.chiasma_tests.base import ChiasmaBaseTests
 
 

--- a/tests/unit/chiasma_tests/chiasma_deploy_tests.py
+++ b/tests/unit/chiasma_tests/chiasma_deploy_tests.py
@@ -81,7 +81,15 @@ class ChiasmaDeployTests(ChiasmaBaseTests):
         user_manaul_path = r'c:\xxx\chiasma\doc\chiasma-user-manual-v1.0.0.pdf'
         self.assertTrue(self.os_module.path.exists(user_manaul_path))
 
-
+    def test_move_release_history__release_history_exists__release_history_moved(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_file_in_latest_candidate_dir(r'release-history.txt')
+        # Act
+        self.chiasma.deployer.common_deployer.copy_release_history()
+        # Assert
+        release_history = r'c:\xxx\chiasma\doc\release-history.txt'
+        self.assertTrue(self.os_module.path.exists(release_history))
 
 
 class FileSystemBuilder:
@@ -99,4 +107,9 @@ class FileSystemBuilder:
 
     def add_file_in_current_candidate_dir(self, filename='file.txt'):
         path = os.path.join(self.chiasma.path_properties.current_candidate_dir, filename)
+        self.filesystem.CreateFile(path)
+
+    def add_file_in_latest_candidate_dir(self, filename='file.txt'):
+        path = os.path.join(self.chiasma.path_properties.latest_accepted_candidate_dir, filename)
+        print('add file into: {}'.format(path))
         self.filesystem.CreateFile(path)

--- a/tests/unit/chiasma_tests/chiasma_validation_deploy_tests.py
+++ b/tests/unit/chiasma_tests/chiasma_validation_deploy_tests.py
@@ -9,7 +9,7 @@ class ChiasmaValidationDeployTests(ChiasmaBaseTests):
         self.file_builder = FileSystemBuilder(self.chiasma, self.filesystem)
 
     def test_create_shortcut__with_latest_empty__something_is_copied_to_latest(self):
-        self.chiasma.validation_deployer.create_shortcut()
+        self.chiasma.validation_deployer.path_actions.create_shortcut_to_exe()
         self.assertTrue(self.os_module.path.exists(r'c:\xxx\chiasma\uservalidations\latest\chiasma.lnk'))
 
     def test_create_shortcut__with_shortcut_exists_in_target__copy_without_error(self):
@@ -17,7 +17,7 @@ class ChiasmaValidationDeployTests(ChiasmaBaseTests):
         self.filesystem.CreateFile(fake_destination_link)
 
         # Act
-        self.chiasma.validation_deployer.create_shortcut()
+        self.chiasma.validation_deployer.path_actions.create_shortcut_to_exe()
 
         # Assert
         self.assertTrue(self.os_module.path.exists(r'c:\xxx\chiasma\uservalidations\latest\chiasma.lnk'))
@@ -29,7 +29,7 @@ class ChiasmaValidationDeployTests(ChiasmaBaseTests):
         dest_shortcut_path = r'c:\xxx\chiasma\uservalidations\latest\chiasma.lnk'
 
         # Act
-        self.chiasma.validation_deployer.create_shortcut()
+        self.chiasma.validation_deployer.run()
         shortcut_target = self.chiasma.validation_deployer.shortcut_examiner.\
             _extract_shortcut_target(dest_shortcut_path)
 

--- a/tests/unit/chiasma_tests/chiasma_validation_deploy_tests.py
+++ b/tests/unit/chiasma_tests/chiasma_validation_deploy_tests.py
@@ -1,39 +1,12 @@
-import unittest
 import os
 from unittest import skip
-from pyfakefs import fake_filesystem
-from release_ccharp.snpseq_workflow import SnpseqWorkflow
-from release_ccharp.snpseq_paths import SnpseqPathActions
-from release_ccharp.apps.chiasma import Application
-from tests.unit.utility.fake_os_service import FakeOsService
-from tests.unit.utility.fake_windows_commands import FakeWindowsCommands
+from tests.unit.chiasma_tests.base import ChiasmaBaseTests
 
 
-class ChiasmaValidationDeployTests(unittest.TestCase):
+class ChiasmaValidationDeployTests(ChiasmaBaseTests):
     def setUp(self):
-        config = {
-            "root_path": r'c:\xxx',
-            "git_repo_name": "chiasma",
-            "exe_file_name_base": "Chiasma",
-            "owner": "GitEdvard"
-        }
-        branch_provider = FakeBranchProvider()
-        wf = SnpseqWorkflow(whatif=False, repo="chiasma")
-        wf.config = config
-        wf.paths.config = config
-        wf.paths.branch_provider = branch_provider
-        self.filesystem = fake_filesystem.FakeFilesystem()
-        os_service = FakeOsService(self.filesystem)
-        self.os_module = os_service.os_module
-        self.chiasma = Application(wf, branch_provider, os_service,
-                                   FakeWindowsCommands(self.filesystem), whatif=False)
+        self.base_setup()
         self.file_builder = FileSystemBuilder(self.chiasma, self.filesystem)
-
-        path_actions = SnpseqPathActions(
-            whatif=False, snpseq_path_properties=self.chiasma.path_properties,
-            os_service=os_service
-        )
-        path_actions.generate_folder_tree()
 
     def test_create_shortcut__with_latest_empty__something_is_copied_to_latest(self):
         self.chiasma.validation_deployer.create_shortcut()
@@ -231,13 +204,6 @@ class ChiasmaValidationDeployTests(unittest.TestCase):
         latest = r'c:\xxx\chiasma\uservalidations\latest'
         dir_objects = [o for o in self.chiasma.os_service.listdir(latest)]
         self.assertEqual(2, len(dir_objects))
-
-
-class FakeBranchProvider:
-    def __init__(self):
-        self.candidate_version = "1.0.0"
-        self.latest_version = "latest-version"
-        self.candidate_branch = "release-1.0.0"
 
 
 class FileSystemBuilder:

--- a/tests/unit/chiasma_validation_deploy_tests.py
+++ b/tests/unit/chiasma_validation_deploy_tests.py
@@ -14,6 +14,7 @@ class ChiasmaValidationDeployTests(unittest.TestCase):
         config = {
             "root_path": r'c:\xxx',
             "git_repo_name": "chiasma",
+            "exe_file_name_base": "Chiasma",
             "owner": "GitEdvard"
         }
         branch_provider = FakeBranchProvider()

--- a/tests/unit/chiasma_validation_deploy_tests.py
+++ b/tests/unit/chiasma_validation_deploy_tests.py
@@ -232,8 +232,6 @@ class ChiasmaValidationDeployTests(unittest.TestCase):
         self.assertEqual(2, len(dir_objects))
 
 
-
-
 class FakeBranchProvider:
     def __init__(self):
         self.candidate_version = "1.0.0"
@@ -278,4 +276,3 @@ class FileSystemBuilder:
         with self.chiasma.os_service.open(path, 'r') as f:
             c = f.read()
         return c
-

--- a/tests/unit/snpseq_path_actions_tests.py
+++ b/tests/unit/snpseq_path_actions_tests.py
@@ -14,7 +14,7 @@ class SnpseqPathActionsTests(unittest.TestCase):
             "owner": "GitEdvard"
         }
         filesystem = fake_filesystem.FakeFilesystem()
-        self.path_properties = SnpseqPathProperties(config, "chiasma")
+        self.path_properties = SnpseqPathProperties(config, "chiasma", None)
         self.path_properties.branch_provider = FakeBranchProvider()
         self.path_actions = SnpseqPathActions(whatif=False, path_properties=self.path_properties,
                                               os_service=FakeOsService(filesystem))

--- a/tests/unit/snpseq_path_actions_tests.py
+++ b/tests/unit/snpseq_path_actions_tests.py
@@ -16,7 +16,7 @@ class SnpseqPathActionsTests(unittest.TestCase):
         filesystem = fake_filesystem.FakeFilesystem()
         self.path_properties = SnpseqPathProperties(config, "chiasma")
         self.path_properties.branch_provider = FakeBranchProvider()
-        self.path_actions = SnpseqPathActions(whatif=False, snpseq_path_properties=self.path_properties,
+        self.path_actions = SnpseqPathActions(whatif=False, path_properties=self.path_properties,
                                               os_service=FakeOsService(filesystem))
 
     def test_find_version_from_candidate_path__with_release_candidate__returns_ok(self):

--- a/tests/unit/snpseq_path_properties_test.py
+++ b/tests/unit/snpseq_path_properties_test.py
@@ -9,7 +9,7 @@ class SnpseqPathPropertiesTests(unittest.TestCase):
             "git_repo_name": "chiasma",
             "owner": "GitEdvard"
         }
-        self.path_properties = SnpseqPathProperties(config, "chiasma")
+        self.path_properties = SnpseqPathProperties(config, "chiasma", None)
         self.path_properties.branch_provider = FakeBranchProvider()
 
     def test_validation_archive__with_branch_provider_as_below__path_is_right(self):

--- a/tests/unit/utils_tests.py
+++ b/tests/unit/utils_tests.py
@@ -1,8 +1,14 @@
 import unittest
+from unittest import skip
+import os
 from pyfakefs import fake_filesystem
 from release_ccharp.utils import copytree_preserve_existing
+from release_ccharp.utils import copytree_replace_existing
 from release_ccharp.utils import delete_directory_contents
 from release_ccharp.utils import create_dirs
+from release_ccharp.utils import DirectoryIterator
+from release_ccharp.utils import FileIterator
+from release_ccharp.utils import TestIterator
 from tests.unit.utility.fake_os_service import FakeOsService
 
 
@@ -62,6 +68,41 @@ class TestCopyTree(unittest.TestCase):
 
         self.assertEqual('original text', contents)
 
+    def test__calling_copytree_twice_with_different_dest_directories__files_copied(self):
+        create_dirs(self.os_service, r'c:\src\subdir1')
+        create_dirs(self.os_service, r'c:\src\subdir2')
+        create_dirs(self.os_service, r'c:\src\subdir1\dir1')
+        create_dirs(self.os_service, r'c:\src\subdir2\dir2')
+        self.filesystem.CreateFile(r'c:\src\subdir1\dir1\file1.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir2\dir2\file2.txt')
+        source1 = r'c:\src\subdir1'
+        source2 = r'c:\src\subdir2'
+        copytree_preserve_existing(self.os_service, source1, self.dest)
+        copytree_preserve_existing(self.os_service, source2, self.dest)
+
+        self.assertTrue(self.os_service.exists(r'c:\dst\dir1\file1.txt'))
+        self.assertTrue(self.os_service.exists(r'c:\dst\dir2\file2.txt'))
+
+    def test__copy_delete_and_copy_with_depth_2_in_source__files_copied(self):
+        create_dirs(self.os_service, r'c:\src\dir1\dir2')
+        self.filesystem.CreateFile(r'c:\src\dir1\dir2\file.txt')
+        copytree_preserve_existing(self.os_service, self.source, self.dest)
+
+        self.assertTrue(self.os_service.exists(r'c:\dst\dir1\dir2\file.txt'))
+
+        delete_directory_contents(self.os_service, r'c:\dst\dir1')
+
+        copytree_preserve_existing(self.os_service, self.source, self.dest)
+
+        self.assertTrue(self.os_service.exists(r'c:\dst\dir1\dir2\file.txt'))
+
+    def test__copy_to_non_existent_folder__files_copied(self):
+        self.filesystem.CreateFile(r'c:\src\file.txt')
+        dest = r'c:\dst\dir1'
+        copytree_preserve_existing(self.os_service, self.source, dest)
+
+        self.assertTrue(self.os_service.exists(r'c:\dst\dir1\file.txt'))
+
 
 class TestDeleteDirectoryContents(unittest.TestCase):
     def setUp(self):
@@ -88,3 +129,267 @@ class TestDeleteDirectoryContents(unittest.TestCase):
     def test_remove_path1__anotherfolder_exists(self):
         delete_directory_contents(self.os_service, r'c:\path1')
         self.assertTrue(self.os_service.exists(self.another_folder))
+
+
+class TestCopytreeReplaceExisting(unittest.TestCase):
+    def setUp(self):
+        self.filesystem = fake_filesystem.FakeFilesystem()
+        self.os_service = FakeOsService(self.filesystem)
+        self.source = r'c:\src'
+        self.dest = r'c:\dst'
+        create_dirs(self.os_service, self.source)
+        create_dirs(self.os_service, self.dest)
+
+    def test__with_one_file_in_source_dest_empty__file_copied(self):
+        self.filesystem.CreateFile(r'c:\src\file1.txt')
+        copytree_replace_existing(self.os_service, self.source, self.dest)
+        self.assertTrue(self.os_service.exists(r'c:\dst\file1.txt'))
+
+    def test__with_one_file_in_source_dest_have_same_file__file_replaced(self):
+        self.filesystem.CreateFile(r'c:\src\file1.txt', contents='source')
+        self.filesystem.CreateFile(r'c:\dst\file1.txt', contents='destination')
+        copytree_replace_existing(self.os_service, self.source, self.dest)
+        with self.os_service.open(r'c:\dst\file1.txt', 'r') as f:
+            c = f.read()
+        self.assertEqual('source', c)
+
+    def test__with_one_file_in_source_dest_have_two_files__extra_file_in_dest_untoutched(self):
+        self.filesystem.CreateFile(r'c:\src\file1.txt')
+        self.filesystem.CreateFile(r'c:\dst\file1.txt')
+        self.filesystem.CreateFile(r'c:\dst\file2.txt', contents='destination')
+        copytree_replace_existing(self.os_service, self.source, self.dest)
+        with self.os_service.open(r'c:\dst\file2.txt', 'r') as f:
+            c = f.read()
+        self.assertEqual('destination', c)
+
+    def test__with_two_subdirs_in_source_one_common_file__source_exclusive_copied(self):
+        # Arrange
+        create_dirs(self.os_service, r'c:\src\subdir1')
+        create_dirs(self.os_service, r'c:\src\subdir2')
+        create_dirs(self.os_service, r'c:\dst\subdir2')
+        self.filesystem.CreateFile(r'c:\src\source_exclusive1.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir1\source_exclusive2.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir1\source_exclusive3.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir2\common.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir2\source_exclusive4.txt')
+        self.filesystem.CreateFile(r'c:\dst\subdir2\common.txt')
+        self.filesystem.CreateFile(r'c:\dst\subdir2\dst_exclusive', contents='destination')
+
+        # Act
+        copytree_replace_existing(self.os_service, self.source, self.dest)
+
+        # Assert
+        self.assertTrue(self.os_service.exists(r'c:\dst\source_exclusive1.txt'))
+        self.assertTrue(self.os_service.exists(r'c:\dst\subdir1\source_exclusive2.txt'))
+        self.assertTrue(self.os_service.exists(r'c:\dst\subdir1\source_exclusive3.txt'))
+        self.assertTrue(self.os_service.exists(r'c:\dst\subdir2\source_exclusive4.txt'))
+
+    def test__with_two_subdirs_in_source_one_common_file__dest_exclusive_preserved(self):
+        # Arrange
+        create_dirs(self.os_service, r'c:\src\subdir1')
+        create_dirs(self.os_service, r'c:\src\subdir2')
+        create_dirs(self.os_service, r'c:\dst\subdir2')
+        self.filesystem.CreateFile(r'c:\src\source_exclusive1.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir1\source_exclusive2.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir1\source_exclusive3.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir2\common.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir2\source_exclusive4.txt')
+        self.filesystem.CreateFile(r'c:\dst\subdir2\common.txt')
+        self.filesystem.CreateFile(r'c:\dst\subdir2\dst_exclusive.txt', contents='destination')
+
+        # Act
+        copytree_replace_existing(self.os_service, self.source, self.dest)
+
+        # Assert
+        with self.os_service.open(r'c:\dst\subdir2\dst_exclusive.txt', 'r') as f:
+            c = f.read()
+        self.assertEqual("destination", c)
+
+    def test__with_two_subdirs_in_source_one_common_file__common_file_replaced(self):
+        # Arrange
+        create_dirs(self.os_service, r'c:\src\subdir1')
+        create_dirs(self.os_service, r'c:\src\subdir2')
+        create_dirs(self.os_service, r'c:\dst\subdir2')
+        self.filesystem.CreateFile(r'c:\src\source_exclusive1.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir1\source_exclusive2.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir1\source_exclusive3.txt')
+        self.filesystem.CreateFile(r'c:\src\subdir2\common.txt', contents='source')
+        self.filesystem.CreateFile(r'c:\src\subdir2\source_exclusive4.txt')
+        self.filesystem.CreateFile(r'c:\dst\subdir2\common.txt', contents='destination')
+        self.filesystem.CreateFile(r'c:\dst\subdir2\dst_exclusive.txt', contents='destination')
+
+        # Act
+        copytree_replace_existing(self.os_service, self.source, self.dest)
+
+        # Assert
+        with self.os_service.open(r'c:\dst\subdir2\common.txt', 'r') as f:
+            c = f.read()
+        self.assertEqual("source", c)
+
+
+class TestIterators(unittest.TestCase):
+    def setUp(self):
+        self.filesystem = fake_filesystem.FakeFilesystem()
+        self.os_service = FakeOsService(self.filesystem)
+        self.root = r'c:\root'
+        self.filesystem_builder = FileSystemBuilder(self.os_service, self.filesystem)
+        create_dirs(self.os_service, self.root)
+
+    def test_directory_iterator__with_no_subdirectories__zero_iterations(self):
+        # Arrange
+        dir_it = DirectoryIterator(self.os_service, self.root)
+
+        # Act
+        gen = (d for d in dir_it)
+        directories = list(gen)
+
+        # Assert
+        self.assertEqual(0, len(directories))
+
+    def test_directory_iterator__with_one_subdirectory__one_iteration(self):
+        # Arrange
+        create_dirs(self.os_service, r'c:\root\subdir1')
+        dir_it = DirectoryIterator(self.os_service, self.root)
+
+        # Act
+        gen = (d for d in dir_it)
+        directories = list(gen)
+
+        # Assert
+        self.assertEqual(1, len(directories))
+
+    def test_directory_iterator__with_one_subdirectory__iteration_result_ok(self):
+        # Arrange
+        create_dirs(self.os_service, r'c:\root\subdir1')
+        dir_it = DirectoryIterator(self.os_service, self.root)
+
+        # Act
+        gen = (d for d in dir_it)
+        directories = list(gen)
+
+        # Assert
+        self.assertEqual(r'subdir1', directories[0])
+
+    def test_directory_iterator__with_two_subdirectories_depth_1__two_iterations(self):
+        # Arrange
+        create_dirs(self.os_service, r'c:\root\subdir1')
+        create_dirs(self.os_service, r'c:\root\subdir2')
+        dir_it = DirectoryIterator(self.os_service, self.root)
+
+        # Act
+        gen = (d for d in dir_it)
+        directories = list(gen)
+
+        # Assert
+        self.assertEqual(2, len(directories))
+
+    def test_directory_iterator__with_two_subdirectories_depth_1__iteration_results_ok(self):
+        # Arrange
+        create_dirs(self.os_service, r'c:\root\subdir1')
+        create_dirs(self.os_service, r'c:\root\subdir2')
+        dir_it = DirectoryIterator(self.os_service, self.root)
+
+        # Act
+        gen = dir_it
+        directories = sorted(list(gen))
+
+        # Assert
+        self.assertEqual('subdir1', directories[0])
+        self.assertEqual('subdir2', directories[1])
+
+    def test_directory_iterator__with_two_subdirectories_depth_2__two_iterations(self):
+        # Arrange
+        create_dirs(self.os_service, r'c:\root\subdir1')
+        create_dirs(self.os_service, r'c:\root\subdir1\subdir2')
+        dir_it = DirectoryIterator(self.os_service, self.root)
+
+        # Act
+        directories = list(dir_it)
+
+        # Assert
+        self.assertEqual(2, len(directories))
+
+    def test_directory_iterator__with_two_subdirectories_depth_2__iteration_results_ok(self):
+        # Arrange
+        create_dirs(self.os_service, r'c:\root\subdir1')
+        create_dirs(self.os_service, r'c:\root\subdir1\subdir2')
+        dir_it = DirectoryIterator(self.os_service, self.root)
+
+        # Act
+        directories = sorted(list(dir_it))
+
+        # Assert
+        self.assertEqual(r'subdir1', directories[0])
+        self.assertEqual(r'subdir1\subdir2', directories[1])
+
+    def test_directory_iterator__with_depth_2_with_4__six_iterations(self):
+        # Arrange
+        create_dirs(self.os_service, r'c:\root\subdir1')
+        create_dirs(self.os_service, r'c:\root\subdir1\subdir2')
+        create_dirs(self.os_service, r'c:\root\subdir1\subdir3')
+        create_dirs(self.os_service, r'c:\root\subdir4')
+        create_dirs(self.os_service, r'c:\root\subdir4\subdir5')
+        create_dirs(self.os_service, r'c:\root\subdir4\subdir6')
+        dir_it = DirectoryIterator(self.os_service, self.root)
+
+        # Act
+        directories = list(dir_it)
+
+        # Assert
+        self.assertEqual(6, len(directories))
+
+    def test_file_iterator__with_one_single_file__returns_subpath(self):
+        # Arrange
+        self.filesystem.CreateFile(r'c:\root\file1.txt')
+        file_it = FileIterator(self.os_service, self.root)
+
+        # Act
+        files = list(file_it)
+
+        # Assert
+        self.assertEqual(r'file1.txt', files[0])
+
+    def test_file_iterator__with_file_in_subdir__returns_subpath(self):
+        # Arrange
+        self.filesystem.CreateFile(r'c:\root\subdir\file1.txt')
+        file_it = FileIterator(self.os_service, self.root)
+
+        # Act
+        files = list(file_it)
+
+        # Assert
+        self.assertEqual(r'subdir\file1.txt', files[0])
+
+
+class TestTestIterator(unittest.TestCase):
+    def test_generator(self):
+        it = TestIterator()
+        for c in it.create_generator():
+            print(c)
+        # lst = list(it.create_generator())
+        # print(lst[0])
+        self.assertEqual(2, 2)
+
+    def test_recursive_gen(self):
+        it = TestIterator()
+        for c in it.gen2():
+            print(c)
+        self.assertEqual(5, len(list(it.gen2())))
+
+    def test_iteration(self):
+        it = TestIterator()
+
+        lst = list(it)
+
+        self.assertEqual(5, len(lst))
+
+
+class FileSystemBuilder():
+    def __init__(self, os_service, filesystem):
+        self.os_service = os_service
+        self.filesystem = filesystem
+
+    def get_contents(self, path):
+        with self.os_service.open(path, 'r') as f:
+            c = f.read()
+        return c


### PR DESCRIPTION
Deploy has four subtasks:
* Check source files exists
* Move files to deploy catalog
* Move user manual to doc catalog
* Move validation and sql files to archive catalog

Refactorings
Refactor 1:
* Add exe base file name in config
* Add project root name in config
This makes it possible to run through the workflow on the testing-repo but using source code for Chiasma. 

Refactor 2:
* utils, factor out iteration of files and directories respectively, under a given root directory. 

Refactor 3:
* Move methods concering shortcut from ChiasmaValidationDeployer to a common class, accessible for all repos. 

Added functionality, common:
* Add function copytree_replace_existing to utils. 
* Add status command (code copied from release-tools)

