### PR TITLE
Chi 778 Implement workflow for sqat

### DIFF
--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -22,7 +22,7 @@ class Application(ApplicationBase):
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         file_deployer = FileDeployer(
             self.path_properties, self.os_service, snpseq_workflow.config, self.app_paths)
-        self.chiasma_builder = ChiasmaBuilder(self, file_deployer, self.app_paths)
+        self.chiasma_builder = ChiasmaBuilder(self, file_deployer, self.app_paths, self.config)
         path_actions = SnpseqPathActions(
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
         self.validation_deployer = ChiasmaValidationDeployer(

--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -20,9 +20,9 @@ class Application(ApplicationBase):
         self.binary_version_updater = BinaryVersionUpdater(
             whatif=False, config=self.config, path_properties=self.path_properties,
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
-        self.chiasma_builder = ChiasmaBuilder(self)
         file_deployer = FileDeployer(
             self.path_properties, self.os_service, snpseq_workflow.config, self.app_paths)
+        self.chiasma_builder = ChiasmaBuilder(self, file_deployer)
         path_actions = SnpseqPathActions(
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
         self.validation_deployer = ChiasmaValidationDeployer(

--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -22,7 +22,7 @@ class Application(ApplicationBase):
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         file_deployer = FileDeployer(
             self.path_properties, self.os_service, snpseq_workflow.config, self.app_paths)
-        self.chiasma_builder = ChiasmaBuilder(self, file_deployer)
+        self.chiasma_builder = ChiasmaBuilder(self, file_deployer, self.app_paths)
         path_actions = SnpseqPathActions(
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
         self.validation_deployer = ChiasmaValidationDeployer(

--- a/release_ccharp/apps/chiasma_scripts/builder.py
+++ b/release_ccharp/apps/chiasma_scripts/builder.py
@@ -6,10 +6,11 @@ from release_ccharp.utils import create_dirs
 
 
 class ChiasmaBuilder:
-    def __init__(self, chiasma, file_deployer, app_paths):
+    def __init__(self, chiasma, file_deployer, app_paths, config):
         self.chiasma = chiasma
         self.file_deployer = file_deployer
         self.app_paths = app_paths
+        self.config = config
 
     def run(self):
         self.check_build_not_already_run()
@@ -39,7 +40,9 @@ class ChiasmaBuilder:
         raise SnpseqReleaseException("The solution file could not be found, directory {}".format(download_dir))
 
     def move_candidates(self):
-        self.chiasma.app_paths.move_candidates()
+        project_root_path = os.path.join(self.app_paths.download_dir,
+                                         self.config['project_root_dir'])
+        self.chiasma.app_paths.move_candidates(project_root_path)
 
     def _transform_config(self, directory):
         config_file_path = os.path.join(directory, self.chiasma.app_paths.config_file_name)

--- a/release_ccharp/apps/chiasma_scripts/builder.py
+++ b/release_ccharp/apps/chiasma_scripts/builder.py
@@ -6,9 +6,10 @@ from release_ccharp.utils import create_dirs
 
 
 class ChiasmaBuilder:
-    def __init__(self, chiasma, file_deployer):
+    def __init__(self, chiasma, file_deployer, app_paths):
         self.chiasma = chiasma
         self.file_deployer = file_deployer
+        self.app_paths = app_paths
 
     def run(self):
         self.check_build_not_already_run()
@@ -18,7 +19,8 @@ class ChiasmaBuilder:
         self.transform_config()
 
     def update_binary_version(self):
-        self.chiasma.binary_version_updater.update_binary_version()
+        assembly_file_path = self.app_paths.common_assembly_file_path
+        self.chiasma.binary_version_updater.update_binary_version(assembly_file_path)
 
     def check_build_not_already_run(self):
         self.file_deployer.check_build_not_already_run()

--- a/release_ccharp/apps/chiasma_scripts/builder.py
+++ b/release_ccharp/apps/chiasma_scripts/builder.py
@@ -6,8 +6,9 @@ from release_ccharp.utils import create_dirs
 
 
 class ChiasmaBuilder:
-    def __init__(self, chiasma):
+    def __init__(self, chiasma, file_deployer):
         self.chiasma = chiasma
+        self.file_deployer = file_deployer
 
     def run(self):
         self.check_build_not_already_run()
@@ -20,11 +21,7 @@ class ChiasmaBuilder:
         self.chiasma.binary_version_updater.update_binary_version()
 
     def check_build_not_already_run(self):
-        if os.path.exists(self.chiasma.app_paths.production_dir) or \
-                os.path.exists(self.chiasma.app_paths.validation_dir):
-            raise SnpseqReleaseException(
-                ("Production or validation catalog already exists. " 
-                "They need to be removed before continuing"))
+        self.file_deployer.check_build_not_already_run()
 
     def build_solution(self):
         solution_file = self._find_solution_file()

--- a/release_ccharp/apps/chiasma_scripts/builder.py
+++ b/release_ccharp/apps/chiasma_scripts/builder.py
@@ -47,6 +47,7 @@ class ChiasmaBuilder:
     def _transform_config(self, directory):
         config_file_path = os.path.join(directory, self.chiasma.app_paths.config_file_name)
         db_name = "GTDB2" if directory == self.chiasma.app_paths.production_dir else "GTDB2_practice"
+        self.chiasma.save_backup_file(config_file_path)
         with self.chiasma.open_xml(config_file_path) as xml:
             config = StandardVSConfigXML(xml, "Molmed.Chiasma")
             config.update("EnforceAppVersion", "True")
@@ -59,7 +60,7 @@ class ChiasmaBuilder:
                     self.chiasma.whatif)
         lab_config_file_path = os.path.join(lab_config_dir, self.chiasma.app_paths.config_file_name)
         self.chiasma.os_service.copyfile(config_file_path, lab_config_file_path)
-        with self.chiasma.open_xml(lab_config_file_path, backup_origfile=False) as xml:
+        with self.chiasma.open_xml(lab_config_file_path) as xml:
             config = StandardVSConfigXML(xml, "Molmed.Chiasma")
             config.update("ApplicationMode", "LAB")
 

--- a/release_ccharp/apps/chiasma_scripts/builder.py
+++ b/release_ccharp/apps/chiasma_scripts/builder.py
@@ -42,7 +42,7 @@ class ChiasmaBuilder:
     def move_candidates(self):
         project_root_path = os.path.join(self.app_paths.download_dir,
                                          self.config['project_root_dir'])
-        self.chiasma.app_paths.move_candidates(project_root_path)
+        self.chiasma.app_paths.common_move_candidates(project_root_path)
 
     def _transform_config(self, directory):
         config_file_path = os.path.join(directory, self.chiasma.app_paths.config_file_name)

--- a/release_ccharp/apps/common/base.py
+++ b/release_ccharp/apps/common/base.py
@@ -21,13 +21,15 @@ class ApplicationBase(object):
         self.app_paths = AppPaths(self.config, self.path_properties, os_service)
         self.windows_commands = windows_commands
 
-    @contextmanager
-    def open_xml(self, path, backup_origfile=True):
+    def save_backup_file(self, path):
         orig_file_path = "{}.orig".format(path)
-        self.log("Updating xml file: {}".format(path))
-        if backup_origfile and not os.path.exists(orig_file_path):
+        if not os.path.exists(orig_file_path):
             self.log("Saving backup of original file: {}".format(orig_file_path))
             self.os_service.copyfile(path, orig_file_path)
+
+    @contextmanager
+    def open_xml(self, path):
+        self.log("Updating xml file: {}".format(path))
         tree = self.os_service.et_parse(path)
         yield tree.getroot()
         self.os_service.et_write(tree, path)

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+from release_ccharp.exceptions import SnpseqReleaseException
 from release_ccharp.utils import lazyprop
 from release_ccharp.snpseq_paths import SnpseqPathActions
 from release_ccharp.utils import copytree_preserve_existing
@@ -142,6 +143,13 @@ class FileDeployer:
         dst = os.path.join(self.path_properties.doc, release_history_base_name)
         self.os_service.copyfile(src_release_history, dst)
         print('ok')
+
+    def check_not_already_run(self):
+        if self.os_service.exists(self.app_paths.production_dir) or \
+                self.os_service.exists(self.app_paths.validation_dir):
+            raise SnpseqReleaseException(
+                ("Production or validation catalog already exists. " 
+                "They need to be removed before continuing"))
 
 
 class FileDoesNotExistsException(Exception):

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -54,7 +54,7 @@ class AppPaths:
     def config_file_name(self):
         return "{}.exe.config".format(self.config["exe_file_name_base"])
 
-    def move_candidates(self, project_root_directory):
+    def common_move_candidates(self, project_root_directory):
         bin_dir = os.path.join(project_root_directory, 'bin')
         release_dir = os.path.join(bin_dir, 'release')
         self.os_service.copytree(release_dir, self.validation_dir)

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -59,6 +59,17 @@ class AppPaths:
         self.os_service.copytree(release_dir, self.validation_dir)
         self.os_service.copytree(release_dir, self.production_dir)
 
+    @lazyprop
+    def common_assembly_file_path(self):
+        properties = os.path.join(self.config["project_root_dir"], 'properties')
+        assembly_subpath = os.path.join(properties, 'assemblyinfo.cs')
+        assembly_file_path = os.path.join(
+            self.download_dir, assembly_subpath)
+        if not self.os_service.exists(assembly_file_path):
+            raise SnpseqReleaseException(
+                "The assembly info file could not be found {}".format(assembly_file_path))
+        return assembly_file_path
+
 
 class FileDeployer:
     def __init__(self, path_properties, os_service, config, app_paths):

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -25,14 +25,16 @@ class AppPaths:
         oss = self.os_service
         dir_lst = [o for o in oss.listdir(candidate_dir) if oss.isdir(os.path.join(candidate_dir, o))]
         for d in dir_lst:
-            if pattern in d:
+            if pattern.lower() in d.lower():
                 return d
-        return None
+        raise SnpseqReleaseException(
+            'download directory could not be found under candidate path \n {}'.format(candidate_dir))
 
     @lazyprop
     def download_dir(self):
+        download_directory_name = self.find_download_directory_name()
         return os.path.join(self.path_properties.current_candidate_dir,
-                            self.find_download_directory_name())
+                            download_directory_name)
 
     @lazyprop
     def validation_dir(self):
@@ -52,10 +54,9 @@ class AppPaths:
     def config_file_name(self):
         return "{}.exe.config".format(self.config["exe_file_name_base"])
 
-    def move_candidates(self):
-        bin = os.path.join(self.config["project_root_dir"], 'bin')
-        release_subdir = os.path.join(bin, 'release')
-        release_dir = os.path.join(self.download_dir, release_subdir)
+    def move_candidates(self, project_root_directory):
+        bin_dir = os.path.join(project_root_directory, 'bin')
+        release_dir = os.path.join(bin_dir, 'release')
         self.os_service.copytree(release_dir, self.validation_dir)
         self.os_service.copytree(release_dir, self.production_dir)
 

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -118,6 +118,11 @@ class FileDeployer:
         if not self.os_service.exists(exe):
             raise FileDoesNotExistsException(exe)
 
+    def check_file_in_production_exists(self, file_name):
+        file_path = os.path.join(self.app_paths.production_dir, file_name)
+        if not self.os_service.exists(file_path):
+            raise FileDoesNotExistsException(file_path)
+
     def check_config_file_exists(self):
         config = os.path.join(self.app_paths.production_dir, self.app_paths.config_file_name)
         if not self.os_service.exists(config):

--- a/release_ccharp/apps/sqat.py
+++ b/release_ccharp/apps/sqat.py
@@ -7,6 +7,7 @@ from release_ccharp.apps.common.single_file_read_write import BinaryVersionUpdat
 from release_ccharp.apps.sqat_scripts.builder import SqatBuilder
 from release_ccharp.apps.sqat_scripts.validation_deployer import SqatValidationDeployer
 from release_ccharp.apps.sqat_scripts.deployer import SqatDeployer
+from release_ccharp.apps.common.single_file_read_write import ShortcutExaminer
 
 
 class Application(ApplicationBase):
@@ -20,11 +21,17 @@ class Application(ApplicationBase):
             whatif=False, config=self.config, path_properties=self.path_properties,
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         file_deployer = FileDeployer(self.path_properties, os_service, self.config, self.app_paths)
-        self.builder = SqatBuilder(self, os_service, self.app_paths, file_deployer,
-                                   binary_version_updater, windows_commands)
+        self.builder = SqatBuilder(self, os_service, self.path_properties, self.app_paths,
+                                   file_deployer, binary_version_updater, windows_commands)
         path_actions = SnpseqPathActions(
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
-        self.validation_deployer = SqatValidationDeployer(self, file_deployer, path_actions)
+
+        shortcut_examiner = ShortcutExaminer(
+            branch_provider, os_service, windows_commands,
+            file_deployer, self.path_properties.shortcut_path)
+
+        self.validation_deployer = SqatValidationDeployer(self, file_deployer, path_actions, shortcut_examiner,
+                                                          os_service, self.path_properties)
         self.deployer = SqatDeployer(self.path_properties, file_deployer, path_actions,
                                      self.os_service, self.branch_provider)
 
@@ -42,8 +49,14 @@ class Application(ApplicationBase):
 
     def download_release_history(self):
         super(Application, self).download_release_history()
+        self.snpseq_workflow.download_release_history()
+        self.deployer.copy_release_history()
 
     @property
     def project_root_dir(self):
         application_path = os.path.join(self.app_paths.download_dir, 'application')
         return os.path.join(application_path, self.config['project_root_dir'])
+
+    @property
+    def user_manual_file_name(self):
+        return 'User Manual SNP Quality Analysis Tool.doc'

--- a/release_ccharp/apps/sqat.py
+++ b/release_ccharp/apps/sqat.py
@@ -6,6 +6,7 @@ from release_ccharp.apps.common.directory_handling import FileDeployer
 from release_ccharp.apps.common.single_file_read_write import BinaryVersionUpdater
 from release_ccharp.apps.sqat_scripts.builder import SqatBuilder
 from release_ccharp.apps.sqat_scripts.validation_deployer import SqatValidationDeployer
+from release_ccharp.apps.sqat_scripts.deployer import SqatDeployer
 
 
 class Application(ApplicationBase):
@@ -24,6 +25,8 @@ class Application(ApplicationBase):
         path_actions = SnpseqPathActions(
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
         self.validation_deployer = SqatValidationDeployer(self, file_deployer, path_actions)
+        self.deployer = SqatDeployer(self.path_properties, file_deployer, path_actions,
+                                     self.os_service, self.branch_provider)
 
     def build(self):
         super(Application, self).build()
@@ -35,6 +38,7 @@ class Application(ApplicationBase):
 
     def deploy(self):
         super(Application, self).deploy()
+        self.deployer.run()
 
     def download_release_history(self):
         super(Application, self).download_release_history()

--- a/release_ccharp/apps/sqat.py
+++ b/release_ccharp/apps/sqat.py
@@ -17,7 +17,8 @@ class Application(ApplicationBase):
             whatif=False, config=self.config, path_properties=self.path_properties,
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         file_deployer = FileDeployer(self.path_properties, os_service, self.config, self.app_paths)
-        self.builder = SqatBuilder(self, os_service, self.app_paths, file_deployer, binary_version_updater)
+        self.builder = SqatBuilder(self, os_service, self.app_paths, file_deployer,
+                                   binary_version_updater, windows_commands)
 
     def build(self):
         super(Application, self).build()

--- a/release_ccharp/apps/sqat.py
+++ b/release_ccharp/apps/sqat.py
@@ -1,0 +1,27 @@
+from __future__ import print_function
+from release_ccharp.apps.common.base import ApplicationBase
+from release_ccharp.apps.sqat_scripts.builder import SqatBuilder
+from release_ccharp.apps.common.directory_handling import FileDeployer
+
+
+class Application(ApplicationBase):
+    """
+    Code that is specific to the SQAT application
+    """
+    def __init__(self, snpseq_workflow, branch_provider, os_service, windows_commands, whatif):
+        super(Application, self).__init__(snpseq_workflow, branch_provider, os_service,
+                                          windows_commands, whatif)
+        file_deployer = FileDeployer(self.path_properties, os_service, self.config, self.app_paths)
+        self.builder = SqatBuilder(os_service, self.app_paths, file_deployer)
+
+    def build(self):
+        super(Application, self).build()
+
+    def deploy_validation(self):
+        super(Application, self).deploy_validation()
+
+    def deploy(self):
+        super(Application, self).deploy()
+
+    def download_release_history(self):
+        super(Application, self).download_release_history()

--- a/release_ccharp/apps/sqat.py
+++ b/release_ccharp/apps/sqat.py
@@ -1,9 +1,11 @@
 from __future__ import print_function
 import os
+from release_ccharp.snpseq_paths import SnpseqPathActions
 from release_ccharp.apps.common.base import ApplicationBase
 from release_ccharp.apps.common.directory_handling import FileDeployer
 from release_ccharp.apps.common.single_file_read_write import BinaryVersionUpdater
 from release_ccharp.apps.sqat_scripts.builder import SqatBuilder
+from release_ccharp.apps.sqat_scripts.validation_deployer import SqatValidationDeployer
 
 
 class Application(ApplicationBase):
@@ -19,6 +21,9 @@ class Application(ApplicationBase):
         file_deployer = FileDeployer(self.path_properties, os_service, self.config, self.app_paths)
         self.builder = SqatBuilder(self, os_service, self.app_paths, file_deployer,
                                    binary_version_updater, windows_commands)
+        path_actions = SnpseqPathActions(
+            whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
+        self.validation_deployer = SqatValidationDeployer(self, file_deployer, path_actions)
 
     def build(self):
         super(Application, self).build()
@@ -26,6 +31,7 @@ class Application(ApplicationBase):
 
     def deploy_validation(self):
         super(Application, self).deploy_validation()
+        self.validation_deployer.run()
 
     def deploy(self):
         super(Application, self).deploy()

--- a/release_ccharp/apps/sqat.py
+++ b/release_ccharp/apps/sqat.py
@@ -1,7 +1,9 @@
 from __future__ import print_function
+import os
 from release_ccharp.apps.common.base import ApplicationBase
-from release_ccharp.apps.sqat_scripts.builder import SqatBuilder
 from release_ccharp.apps.common.directory_handling import FileDeployer
+from release_ccharp.apps.common.single_file_read_write import BinaryVersionUpdater
+from release_ccharp.apps.sqat_scripts.builder import SqatBuilder
 
 
 class Application(ApplicationBase):
@@ -11,11 +13,15 @@ class Application(ApplicationBase):
     def __init__(self, snpseq_workflow, branch_provider, os_service, windows_commands, whatif):
         super(Application, self).__init__(snpseq_workflow, branch_provider, os_service,
                                           windows_commands, whatif)
+        binary_version_updater = BinaryVersionUpdater(
+            whatif=False, config=self.config, path_properties=self.path_properties,
+            branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         file_deployer = FileDeployer(self.path_properties, os_service, self.config, self.app_paths)
-        self.builder = SqatBuilder(os_service, self.app_paths, file_deployer)
+        self.builder = SqatBuilder(self, os_service, self.app_paths, file_deployer, binary_version_updater)
 
     def build(self):
         super(Application, self).build()
+        self.builder.run()
 
     def deploy_validation(self):
         super(Application, self).deploy_validation()
@@ -25,3 +31,8 @@ class Application(ApplicationBase):
 
     def download_release_history(self):
         super(Application, self).download_release_history()
+
+    @property
+    def project_root_dir(self):
+        application_path = os.path.join(self.app_paths.download_dir, 'application')
+        return os.path.join(application_path, self.config['project_root_dir'])

--- a/release_ccharp/apps/sqat_scripts/builder.py
+++ b/release_ccharp/apps/sqat_scripts/builder.py
@@ -17,6 +17,7 @@ class SqatBuilder:
         self.check_not_already_run()
         self.update_binary_version()
         self.build_solution()
+        self.move_candidates()
 
     def check_not_already_run(self):
         self.file_deployer.check_not_already_run()
@@ -26,6 +27,20 @@ class SqatBuilder:
 
     def build_solution(self):
         self.windows_commands.build_solution(self.solution_file_path)
+
+    def move_candidates(self):
+        self.app_paths.common_move_candidates(self.sqat.project_root_dir)
+        config_src = os.path.join(self.sqat.project_root_dir, 'SQATconfig.xml')
+        connect_src = os.path.join(self.sqat.project_root_dir, 'SQATconnect.xml')
+        config_dst_validation = os.path.join(self.app_paths.validation_dir, 'SQATconfig.xml')
+        config_dst_production = os.path.join(self.app_paths.production_dir, 'SQATconfig.xml')
+        connect_dst_validation = os.path.join(self.app_paths.validation_dir, 'SQATconnect.xml')
+        connect_dst_production = os.path.join(self.app_paths.production_dir, 'SQATconnect.xml')
+
+        self.os_service.copyfile(config_src, config_dst_validation)
+        self.os_service.copyfile(config_src, config_dst_production)
+        self.os_service.copyfile(connect_src, connect_dst_validation)
+        self.os_service.copyfile(connect_src, connect_dst_production)
 
     @lazyprop
     def _assembly_file_path(self):

--- a/release_ccharp/apps/sqat_scripts/builder.py
+++ b/release_ccharp/apps/sqat_scripts/builder.py
@@ -5,22 +5,27 @@ from release_ccharp.utils import lazyprop
 
 
 class SqatBuilder:
-    def __init__(self, sqat, os_service, app_paths, file_deployer, binary_version_updater):
+    def __init__(self, sqat, os_service, app_paths, file_deployer, binary_version_updater, windows_commands):
         self.sqat = sqat
         self.os_service = os_service
         self.app_paths = app_paths
         self.file_deployer = file_deployer
         self.binary_version_updater = binary_version_updater
+        self.windows_commands = windows_commands
 
     def run(self):
         self.check_not_already_run()
         self.update_binary_version()
+        self.build_solution()
 
     def check_not_already_run(self):
         self.file_deployer.check_not_already_run()
 
     def update_binary_version(self):
         self.binary_version_updater.update_binary_version(self._assembly_file_path)
+
+    def build_solution(self):
+        self.windows_commands.build_solution(self.solution_file_path)
 
     @lazyprop
     def _assembly_file_path(self):
@@ -29,3 +34,21 @@ class SqatBuilder:
             raise SnpseqReleaseException(
                 "The assembly info file could not be found {}".format(assembly_file_path))
         return assembly_file_path
+
+    def _find_solution_file_name(self):
+        application = self._application_path
+        oss = self.os_service
+        lst = [o for o in oss.listdir(application) if oss.isfile(os.path.join(application, o))]
+        for file in lst:
+            if file.endswith(".sln"):
+                return file
+        raise SnpseqReleaseException("The solution file could not be found, directory {}".format(application))
+
+    @lazyprop
+    def solution_file_path(self):
+        return os.path.join(self._application_path, self._find_solution_file_name())
+
+    @lazyprop
+    def _application_path(self):
+        download_dir = self.app_paths.download_dir
+        return os.path.join(download_dir, 'application')

--- a/release_ccharp/apps/sqat_scripts/builder.py
+++ b/release_ccharp/apps/sqat_scripts/builder.py
@@ -1,14 +1,31 @@
 from __future__ import print_function
+import os
+from release_ccharp.exceptions import SnpseqReleaseException
+from release_ccharp.utils import lazyprop
 
 
 class SqatBuilder:
-    def __init__(self, os_service, app_paths, file_deployer):
+    def __init__(self, sqat, os_service, app_paths, file_deployer, binary_version_updater):
+        self.sqat = sqat
         self.os_service = os_service
         self.app_paths = app_paths
         self.file_deployer = file_deployer
+        self.binary_version_updater = binary_version_updater
 
     def run(self):
         self.check_not_already_run()
+        self.update_binary_version()
 
     def check_not_already_run(self):
         self.file_deployer.check_not_already_run()
+
+    def update_binary_version(self):
+        self.binary_version_updater.update_binary_version(self._assembly_file_path)
+
+    @lazyprop
+    def _assembly_file_path(self):
+        assembly_file_path = os.path.join(self.sqat.project_root_dir, 'AssemblyInfo.cs')
+        if not self.os_service.exists(assembly_file_path):
+            raise SnpseqReleaseException(
+                "The assembly info file could not be found {}".format(assembly_file_path))
+        return assembly_file_path

--- a/release_ccharp/apps/sqat_scripts/builder.py
+++ b/release_ccharp/apps/sqat_scripts/builder.py
@@ -1,0 +1,14 @@
+from __future__ import print_function
+
+
+class SqatBuilder:
+    def __init__(self, os_service, app_paths, file_deployer):
+        self.os_service = os_service
+        self.app_paths = app_paths
+        self.file_deployer = file_deployer
+
+    def run(self):
+        self.check_not_already_run()
+
+    def check_not_already_run(self):
+        self.file_deployer.check_not_already_run()

--- a/release_ccharp/apps/sqat_scripts/deployer.py
+++ b/release_ccharp/apps/sqat_scripts/deployer.py
@@ -1,0 +1,41 @@
+from __future__ import print_function
+from release_ccharp.utils import delete_directory_contents
+
+
+class SqatDeployer:
+    def __init__(self, path_properties, file_deployer, path_actions, os_service, branch_provider):
+        self.path_properties = path_properties
+        self.file_deployer = file_deployer
+        self.branch_provider = branch_provider
+        self.path_actions = path_actions
+        self.os_service = os_service
+
+    def run(self):
+        self.check_source_files_exists()
+        self.file_deployer.move_deploy_files()
+        self.move_to_archive()
+
+    def check_source_files_exists(self):
+        print('Check that source files exists ...')
+
+        self.file_deployer.check_exe_file_exists()
+        self.file_deployer.check_file_in_production_exists('SQATconfig.xml')
+        self.file_deployer.check_file_in_production_exists('SQATconnect.xml')
+
+        print('ok')
+
+    def copy_release_history(self):
+        self.file_deployer.copy_release_history()
+
+    def move_to_archive(self):
+        """
+        Move files to archive folder matching the current candidate
+        This method have to be called before the candidate version is accepted.
+        :return:
+        """
+        print('Move validation files and sql script to archive...')
+        self.file_deployer.move_latest_to_archive(str(self.branch_provider.candidate_version))
+        self.file_deployer.move_sql_scripts_to_archive(str(self.branch_provider.candidate_version))
+        self.path_actions.create_shortcut_to_exe()
+        delete_directory_contents(self.os_service, self.path_properties.next_validation_files)
+        print('ok')

--- a/release_ccharp/apps/sqat_scripts/validation_deployer.py
+++ b/release_ccharp/apps/sqat_scripts/validation_deployer.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+from release_ccharp.apps.common.single_file_read_write import ShortcutExaminer
+
+
+class SqatValidationDeployer:
+    def __init__(self, sqat, file_deployer, path_actions):
+        self.sqat = sqat
+        self.file_deployer = file_deployer
+        self.os_service = file_deployer.os_service
+        self.shortcut_examiner = ShortcutExaminer(
+            self.sqat.branch_provider, self.os_service, self.sqat.windows_commands,
+            file_deployer, self.sqat.path_properties.shortcut_path)
+        self.path_actions = path_actions
+
+    def run(self):
+        self.copy_validation_files()
+        self.path_actions.create_shortcut_to_exe()
+
+    def copy_validation_files(self):
+        if not self.shortcut_examiner.is_candidate_in_latest:
+            self.file_deployer.move_latest_to_archive(self.shortcut_examiner.version_in_latest)
+        if self.os_service.exists(self.sqat.path_properties.archive_dir_validation_files):
+            self.file_deployer.back_move_from_archive()
+        self.file_deployer.copy_to_latest()

--- a/release_ccharp/apps/sqat_scripts/validation_deployer.py
+++ b/release_ccharp/apps/sqat_scripts/validation_deployer.py
@@ -1,15 +1,16 @@
 from __future__ import print_function
+import os
 from release_ccharp.apps.common.single_file_read_write import ShortcutExaminer
 
 
 class SqatValidationDeployer:
-    def __init__(self, sqat, file_deployer, path_actions):
+    def __init__(self, sqat, file_deployer, path_actions, shortcut_examiner, os_service,
+                 path_properties):
         self.sqat = sqat
         self.file_deployer = file_deployer
-        self.os_service = file_deployer.os_service
-        self.shortcut_examiner = ShortcutExaminer(
-            self.sqat.branch_provider, self.os_service, self.sqat.windows_commands,
-            file_deployer, self.sqat.path_properties.shortcut_path)
+        self.os_service = os_service
+        self.shortcut_examiner = shortcut_examiner
+        self.path_properties = path_properties
         self.path_actions = path_actions
 
     def run(self):
@@ -19,6 +20,6 @@ class SqatValidationDeployer:
     def copy_validation_files(self):
         if not self.shortcut_examiner.is_candidate_in_latest:
             self.file_deployer.move_latest_to_archive(self.shortcut_examiner.version_in_latest)
-        if self.os_service.exists(self.sqat.path_properties.archive_dir_validation_files):
+        if self.os_service.exists(self.path_properties.archive_dir_validation_files):
             self.file_deployer.back_move_from_archive()
         self.file_deployer.copy_to_latest()

--- a/release_ccharp/apps/testing_repo.py
+++ b/release_ccharp/apps/testing_repo.py
@@ -18,9 +18,9 @@ class Application(ApplicationBase):
         self.binary_version_updater = BinaryVersionUpdater(
             whatif=False, config=self.config, path_properties=self.path_properties,
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
-        self.chiasma_builder = ChiasmaBuilder(self)
         file_deployer = FileDeployer(
             self.path_properties, self.os_service, snpseq_workflow.config, self.app_paths)
+        self.chiasma_builder = ChiasmaBuilder(self, file_deployer)
         path_actions = SnpseqPathActions(
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
         self.validation_deployer = ChiasmaValidationDeployer(

--- a/release_ccharp/apps/testing_repo.py
+++ b/release_ccharp/apps/testing_repo.py
@@ -20,7 +20,7 @@ class Application(ApplicationBase):
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         file_deployer = FileDeployer(
             self.path_properties, self.os_service, snpseq_workflow.config, self.app_paths)
-        self.chiasma_builder = ChiasmaBuilder(self, file_deployer)
+        self.chiasma_builder = ChiasmaBuilder(self, file_deployer, self.app_paths)
         path_actions = SnpseqPathActions(
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
         self.validation_deployer = ChiasmaValidationDeployer(

--- a/release_ccharp/apps/testing_repo.py
+++ b/release_ccharp/apps/testing_repo.py
@@ -20,7 +20,7 @@ class Application(ApplicationBase):
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         file_deployer = FileDeployer(
             self.path_properties, self.os_service, snpseq_workflow.config, self.app_paths)
-        self.chiasma_builder = ChiasmaBuilder(self, file_deployer, self.app_paths)
+        self.chiasma_builder = ChiasmaBuilder(self, file_deployer, self.app_paths, self.config)
         path_actions = SnpseqPathActions(
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
         self.validation_deployer = ChiasmaValidationDeployer(

--- a/release_ccharp/apps/testing_repo.py
+++ b/release_ccharp/apps/testing_repo.py
@@ -3,9 +3,14 @@ from release_ccharp.apps.common.single_file_read_write import BinaryVersionUpdat
 from release_ccharp.apps.common.base import ApplicationBase
 from release_ccharp.apps.common.directory_handling import FileDeployer
 from release_ccharp.apps.chiasma_scripts.builder import ChiasmaBuilder
+from release_ccharp.apps.sqat_scripts.builder import SqatBuilder
 from release_ccharp.apps.chiasma_scripts.validation_deployer import ChiasmaValidationDeployer
+from release_ccharp.apps.sqat_scripts.validation_deployer import SqatValidationDeployer
 from release_ccharp.apps.chiasma_scripts.deployer import ChiasmaDeployer
+from release_ccharp.apps.sqat_scripts.deployer import SqatDeployer
+from release_ccharp.apps.common.single_file_read_write import ShortcutExaminer
 from release_ccharp.snpseq_paths import SnpseqPathActions
+from release_ccharp.apps.sqat import Application as SqatApplication
 
 
 class Application(ApplicationBase):
@@ -20,27 +25,45 @@ class Application(ApplicationBase):
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         file_deployer = FileDeployer(
             self.path_properties, self.os_service, snpseq_workflow.config, self.app_paths)
+
+        sqat = SqatApplication(snpseq_workflow, branch_provider, os_service, windows_commands, False)
+
+        # Todo: do something about sending sqat to sqat builder when testing, dangerous!
+        self.sqat_builder = SqatBuilder(sqat, os_service, self.path_properties, self.app_paths,
+                                        file_deployer, self.binary_version_updater, windows_commands)
         self.chiasma_builder = ChiasmaBuilder(self, file_deployer, self.app_paths, self.config)
         path_actions = SnpseqPathActions(
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
-        self.validation_deployer = ChiasmaValidationDeployer(
+        self.chiasma_validation_deployer = ChiasmaValidationDeployer(
             self, file_deployer, path_actions)
-        self.deployer = ChiasmaDeployer(
+
+        shortcut_examiner = ShortcutExaminer(
+            branch_provider, os_service, windows_commands,
+            file_deployer, self.path_properties.shortcut_path)
+
+
+        self.sqat_validation_deployer = SqatValidationDeployer(
+            self, file_deployer, path_actions, shortcut_examiner, os_service, self.path_properties)
+
+        self.chiasma_deployer = ChiasmaDeployer(
             self.path_properties, file_deployer, path_actions, os_service, branch_provider)
+
+        self.sqat_deployer = SqatDeployer(self.path_properties, file_deployer, path_actions,
+                                          os_service, branch_provider)
 
     def build(self):
         super(Application, self).build()
-        self.chiasma_builder.run()
+        self.sqat_builder.run()
 
     def deploy_validation(self):
         super(Application, self).deploy_validation()
-        self.validation_deployer.run()
+        self.sqat_validation_deployer.run()
 
     def deploy(self):
         super(Application, self).deploy()
-        self.deployer.run()
+        self.sqat_deployer.run()
 
     def download_release_history(self):
         super(Application, self).download_release_history()
         self.snpseq_workflow.download_release_history()
-        self.deployer.copy_release_history()
+        self.sqat_deployer.copy_release_history()

--- a/release_ccharp/exceptions.py
+++ b/release_ccharp/exceptions.py
@@ -1,2 +1,5 @@
 class SnpseqReleaseException(Exception):
     pass
+
+class SnpseqXmlEntryNotFoundException(Exception):
+    pass

--- a/release_ccharp/repo.config
+++ b/release_ccharp/repo.config
@@ -9,8 +9,8 @@ chiasma :
 testing-repo :
     root_path : C:\Tmp
     git_repo_name : testing-repo
-    exe_file_name_base : Chiasma
-    project_root_dir : Chiasma
+    exe_file_name_base : SNP Quality Analysis Tool
+    project_root_dir : SQAT3Client
     confluence_space_key : CHI
     owner : GitEdvard
     deploy_root_path : C:\Tmp\testing-repo-deploy

--- a/release_ccharp/repo.config
+++ b/release_ccharp/repo.config
@@ -21,3 +21,10 @@ order :
     project_root_dir : PlattformOrdMan
     owner : Molmed
     deploy_root_path : L:\Labsystem\Chiasma\Installation\Klient\Order\Filer
+sqat:
+    root_path : P:\lims
+    git_repo_name : SNPQualityAnalysisTool
+    exe_file_name : SNP Quality Analysis Tool
+    project_root_dir : SQAT3Client
+    owner : Molmed
+    deploy_root_path : L:\Labsystem\Chiasma\Installation\Klient\SNP Quality Analysis Tool

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -169,7 +169,6 @@ class SnpseqPathProperties:
         archive_version_dir = os.path.join(self.all_versions, str(self.branch_provider.candidate_version))
         return os.path.join(archive_version_dir, self.user_validations_sql_updates_subpath)
 
-
     @property
     def latest_validation_files(self):
         return os.path.join(self.user_validations_latest, self.user_validations_validation_files_subpath)

--- a/release_ccharp/snpseq_workflow.py
+++ b/release_ccharp/snpseq_workflow.py
@@ -15,9 +15,13 @@ class SnpseqWorkflow:
     """
     Initializes a release-tools workflow to act on the github provider
     """
-    def __init__(self, whatif, repo, os_service):
+    def __init__(self, whatif, repo, os_service, config=None):
         conf = Config()
-        self.config = conf.open_config(repo)
+        self.os_service = os_service
+        if config is None:
+            self.config = conf.open_config(repo)
+        else:
+            self.config = config
         self.whatif = whatif
         self.repo = repo
         self.paths = SnpseqPathProperties(self.config, self.repo, os_service)
@@ -25,7 +29,7 @@ class SnpseqWorkflow:
         self.paths.branch_provider = BranchProvider(self.workflow)
 
     def _open_github_provider_config(self, config_file):
-        with open(config_file) as f:
+        with self.os_service.open(config_file, 'r') as f:
             contents = yaml.load(f)
         return contents['access_token'] if contents and "access_token" in contents else None
 

--- a/release_ccharp/utils.py
+++ b/release_ccharp/utils.py
@@ -11,6 +11,7 @@ def lazyprop(fn):
         return getattr(self, attr_name)
     return _lazyprop
 
+
 def single(seq):
     """Returns the first element in a list, throwing an exception if there is an unexpected number of items"""
     if isinstance(seq, types.GeneratorType):

--- a/tests/unit/app_path_tests.py
+++ b/tests/unit/app_path_tests.py
@@ -48,12 +48,14 @@ class AppPathTests(unittest.TestCase):
         self.assertEqual("Chiasma.exe.config", name)
 
     def test_move_candidates__with_one_file_added_in_bin_release__file_found_in_validation(self):
-        self.app_paths.move_candidates()
+        project_root = r'c:\xxx\chiasma\candidates\new-candidate\gitedvard-chiasma-123\chiasma'
+        self.app_paths.common_move_candidates(project_root)
         expected_file = r'c:\xxx\chiasma\candidates\new-candidate\validation\chiasma.exe'
         self.assertTrue(self.os_module.path.exists(expected_file))
 
     def test_move_candidates__with_one_file_added_in_bin_release__file_found_in_production(self):
-        self.app_paths.move_candidates()
+        project_root = r'c:\xxx\chiasma\candidates\new-candidate\gitedvard-chiasma-123\chiasma'
+        self.app_paths.common_move_candidates(project_root)
         expected_file = r'c:\xxx\chiasma\candidates\new-candidate\production\chiasma.exe'
         self.assertTrue(self.os_module.path.exists(expected_file))
 

--- a/tests/unit/base.py
+++ b/tests/unit/base.py
@@ -1,0 +1,42 @@
+import unittest
+import os
+from pyfakefs import fake_filesystem
+from release_ccharp.snpseq_workflow import SnpseqWorkflow
+from release_ccharp.snpseq_paths import SnpseqPathActions
+from release_ccharp.snpseq_paths import SnpseqPathProperties
+from release_ccharp.utils import create_dirs
+from tests.unit.utility.fake_os_service import FakeOsService
+
+
+class BaseTests(unittest.TestCase):
+    def base_setup(self, config, repo):
+        branch_provider = FakeBranchProvider()
+        self.filesystem = fake_filesystem.FakeFilesystem()
+        os_service = FakeOsService(self.filesystem)
+        self.os_module = os_service.os_module
+        path_properties = SnpseqPathProperties(config, repo, os_service)
+        path_properties.branch_provider = branch_provider
+        self.prepare_folder_tree(os_service, branch_provider, path_properties, self.filesystem)
+        wf = SnpseqWorkflow(whatif=False, repo=repo, os_service=os_service, config=config)
+        wf.paths.branch_provider = branch_provider
+        return wf, branch_provider, os_service
+
+    def prepare_folder_tree(self, os_service, branch_provider, path_properties, filesystem):
+        path_actions = SnpseqPathActions(
+            whatif=False, path_properties=path_properties,
+            os_service=os_service
+        )
+        path_actions.generate_folder_tree()
+        create_dirs(os_service, path_properties.current_candidate_dir, False, False)
+        latest_candidate = 'release-{}'.format(branch_provider.latest_version)
+        latest_dir = os.path.join(path_properties.root_candidates, latest_candidate)
+        create_dirs(os_service, latest_dir, False, False)
+        print('workflow config: {}'.format(path_properties.release_tools_config))
+        filesystem.CreateFile(path_properties.release_tools_config, contents='none')
+
+
+class FakeBranchProvider:
+    def __init__(self):
+        self.candidate_version = "1.0.0"
+        self.latest_version = "0.0.9"
+        self.candidate_branch = "release-1.0.0"

--- a/tests/unit/base.py
+++ b/tests/unit/base.py
@@ -31,7 +31,6 @@ class BaseTests(unittest.TestCase):
         latest_candidate = 'release-{}'.format(branch_provider.latest_version)
         latest_dir = os.path.join(path_properties.root_candidates, latest_candidate)
         create_dirs(os_service, latest_dir, False, False)
-        print('workflow config: {}'.format(path_properties.release_tools_config))
         filesystem.CreateFile(path_properties.release_tools_config, contents='none')
 
 

--- a/tests/unit/chiasma_tests/base.py
+++ b/tests/unit/chiasma_tests/base.py
@@ -14,5 +14,6 @@ class ChiasmaBaseTests(BaseTests):
             "deploy_root_path": r'c:\xxx\deploy'
         }
         wf, branch_provider, os_service = self.base_setup(config, 'chiasma')
+        self.os_service = os_service
         self.chiasma = Application(wf, branch_provider, os_service,
                                    FakeWindowsCommands(self.filesystem), whatif=False)

--- a/tests/unit/chiasma_tests/base.py
+++ b/tests/unit/chiasma_tests/base.py
@@ -1,16 +1,10 @@
-import unittest
-import os
-from pyfakefs import fake_filesystem
-from release_ccharp.snpseq_workflow import SnpseqWorkflow
-from release_ccharp.snpseq_paths import SnpseqPathActions
 from release_ccharp.apps.chiasma import Application
-from release_ccharp.utils import create_dirs
-from tests.unit.utility.fake_os_service import FakeOsService
 from tests.unit.utility.fake_windows_commands import FakeWindowsCommands
+from tests.unit.base import BaseTests
 
 
-class ChiasmaBaseTests(unittest.TestCase):
-    def base_setup(self):
+class ChiasmaBaseTests(BaseTests):
+    def setup_chiasma(self):
         config = {
             "root_path": r'c:\xxx',
             "git_repo_name": "chiasma",
@@ -19,30 +13,6 @@ class ChiasmaBaseTests(unittest.TestCase):
             "owner": "GitEdvard",
             "deploy_root_path": r'c:\xxx\deploy'
         }
-        branch_provider = FakeBranchProvider()
-        self.filesystem = fake_filesystem.FakeFilesystem()
-        os_service = FakeOsService(self.filesystem)
-        self.os_module = os_service.os_module
-        wf = SnpseqWorkflow(whatif=False, repo="chiasma", os_service=os_service)
-        wf.config = config
-        wf.paths.config = config
-        wf.paths.branch_provider = branch_provider
+        wf, branch_provider, os_service = self.base_setup(config, 'chiasma')
         self.chiasma = Application(wf, branch_provider, os_service,
                                    FakeWindowsCommands(self.filesystem), whatif=False)
-
-        path_actions = SnpseqPathActions(
-            whatif=False, path_properties=self.chiasma.path_properties,
-            os_service=os_service
-        )
-        path_actions.generate_folder_tree()
-        create_dirs(os_service, self.chiasma.path_properties.current_candidate_dir, False, False)
-        latest_candidate = 'release-{}'.format(branch_provider.latest_version)
-        latest_dir = os.path.join(self.chiasma.path_properties.root_candidates, latest_candidate)
-        create_dirs(os_service, latest_dir, False, False)
-
-
-class FakeBranchProvider:
-    def __init__(self):
-        self.candidate_version = "1.0.0"
-        self.latest_version = "0.0.9"
-        self.candidate_branch = "release-1.0.0"

--- a/tests/unit/chiasma_tests/chiasma_build_tests_unit.py
+++ b/tests/unit/chiasma_tests/chiasma_build_tests_unit.py
@@ -8,7 +8,7 @@ from tests.unit.chiasma_tests.base import ChiasmaBaseTests
 
 class ChiasmaBuildTests(ChiasmaBaseTests):
     def setUp(self):
-        self.base_setup()
+        self.setup_chiasma()
         chiasma_config_path = (r'c:\xxx\chiasma\candidates\validation\chiasma.exe.config')
         self.filesystem.CreateFile(chiasma_config_path, contents=CHIASMA_CONFIG)
 

--- a/tests/unit/chiasma_tests/chiasma_build_tests_unit.py
+++ b/tests/unit/chiasma_tests/chiasma_build_tests_unit.py
@@ -72,7 +72,7 @@ line 3"""
         validation_dir = r'c:\xxx\chiasma\candidates\validation'
         self.chiasma.chiasma_builder._transform_config(validation_dir)
         config_file_path = r'c:\xxx\chiasma\candidates\validation\chiasma.exe.config.orig'
-        with self.chiasma.open_xml(config_file_path, backup_origfile=False) as xml:
+        with self.chiasma.open_xml(config_file_path) as xml:
             config = StandardVSConfigXML(xml, "Molmed.Chiasma")
             self.assertEqual("False", config.get('DilutePlateAutomaticLabelPrint'))
 
@@ -86,7 +86,7 @@ line 3"""
         validation_dir = r'c:\xxx\chiasma\candidates\validation'
         self.chiasma.chiasma_builder._transform_config(validation_dir)
         config_file_path = r'c:\xxx\chiasma\candidates\validation\chiasma.exe.config'
-        with self.chiasma.open_xml(config_file_path, backup_origfile=False) as xml:
+        with self.chiasma.open_xml(config_file_path) as xml:
             config = StandardVSConfigXML(xml, "Molmed.Chiasma")
             self.assertEqual("OFFICE", config.get('ApplicationMode'))
             self.assertEqual("600", config.get("RandomProperty"))
@@ -101,7 +101,7 @@ line 3"""
         validation_dir = r'c:\xxx\chiasma\candidates\validation'
         self.chiasma.chiasma_builder._transform_config(validation_dir)
         config_file_path = r'c:\xxx\chiasma\candidates\validation\config_lab\chiasma.exe.config'
-        with self.chiasma.open_xml(config_file_path, backup_origfile=False) as xml:
+        with self.chiasma.open_xml(config_file_path) as xml:
             config = StandardVSConfigXML(xml, "Molmed.Chiasma")
             self.assertEqual("LAB", config.get('ApplicationMode'))
             self.assertEqual("600", config.get("RandomProperty"))

--- a/tests/unit/chiasma_tests/chiasma_build_tests_unit.py
+++ b/tests/unit/chiasma_tests/chiasma_build_tests_unit.py
@@ -1,7 +1,9 @@
 from __future__ import print_function
+import os
 from unittest import skip
 from pyfakefs.fake_filesystem import FakeFileOpen
 from release_ccharp.apps.common.single_file_read_write import StandardVSConfigXML
+from release_ccharp.utils import create_dirs
 from tests.unit.utility.config import CHIASMA_CONFIG
 from tests.unit.chiasma_tests.base import ChiasmaBaseTests
 
@@ -11,6 +13,7 @@ class ChiasmaBuildTests(ChiasmaBaseTests):
         self.setup_chiasma()
         chiasma_config_path = (r'c:\xxx\chiasma\candidates\validation\chiasma.exe.config')
         self.filesystem.CreateFile(chiasma_config_path, contents=CHIASMA_CONFIG)
+        self.file_builder = FileBuilder(self.filesystem, self.os_service)
 
     def test__get_version(self):
         version = self.chiasma.branch_provider.candidate_version
@@ -36,6 +39,28 @@ line 3"""
         contents = file_module(path)
         print(contents)
         self.assertEqual(1, 1)
+
+    def test_move_candidates__with_exe_added_to_release__file_copied_to_production(self):
+        # Arrange
+        self.file_builder.add_file_to_release('chiasma.exe')
+
+        # Act
+        self.chiasma.chiasma_builder.move_candidates()
+
+        # Assert
+        production_exe_path = r'c:\xxx\chiasma\candidates\release-1.0.0\production\chiasma.exe'
+        self.assertTrue(self.os_service.exists(production_exe_path))
+
+    def test_move_candidates__with_exe_added_to_release__file_copied_to_validation(self):
+        # Arrange
+        self.file_builder.add_file_to_release('chiasma.exe')
+
+        # Act
+        self.chiasma.chiasma_builder.move_candidates()
+
+        # Assert
+        production_exe_path = r'c:\xxx\chiasma\candidates\release-1.0.0\validation\chiasma.exe'
+        self.assertTrue(self.os_service.exists(production_exe_path))
 
     def test_transform_config__with_validation_directory__orig_file_backed_up(self):
         validation_dir = r'c:\xxx\chiasma\candidates\validation'
@@ -102,3 +127,18 @@ row3"""
         with file_module(file_path) as f:
             contents = "".join([line for line in f])
         self.assertEqual(expected, contents)
+
+
+class FileBuilder:
+    def __init__(self, filesystem, os_service):
+        self.filesystem = filesystem
+        self.release_dir = r'c:\xxx\chiasma\candidates\release-1.0.0\gitedvard-chiasma-123\chiasma\bin\release'
+        create_dirs(os_service, self.release_dir)
+
+    def add_file_to_release(self, filename='file.txt', contents=''):
+        path = os.path.join(self.release_dir, filename)
+        self._log(path)
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def _log(self, file_path):
+        print('add file into: {}'.format(file_path))

--- a/tests/unit/chiasma_tests/chiasma_deploy_tests.py
+++ b/tests/unit/chiasma_tests/chiasma_deploy_tests.py
@@ -6,7 +6,7 @@ from tests.unit.chiasma_tests.base import ChiasmaBaseTests
 
 class ChiasmaDeployTests(ChiasmaBaseTests):
     def setUp(self):
-        self.base_setup()
+        self.setup_chiasma()
         self.file_builder = FileSystemBuilder(self.chiasma, self.filesystem)
 
     def add_required_files(self):

--- a/tests/unit/chiasma_tests/chiasma_validation_deploy_tests.py
+++ b/tests/unit/chiasma_tests/chiasma_validation_deploy_tests.py
@@ -5,7 +5,7 @@ from tests.unit.chiasma_tests.base import ChiasmaBaseTests
 
 class ChiasmaValidationDeployTests(ChiasmaBaseTests):
     def setUp(self):
-        self.base_setup()
+        self.setup_chiasma()
         self.file_builder = FileSystemBuilder(self.chiasma, self.filesystem)
 
     def test_create_shortcut__with_latest_empty__something_is_copied_to_latest(self):

--- a/tests/unit/sqat_tests/base.py
+++ b/tests/unit/sqat_tests/base.py
@@ -10,7 +10,7 @@ class SqatBaseTests(BaseTests):
         config = {
             "root_path": r'c:\xxx',
             "git_repo_name": "sqat",
-            "exe_file_name_base": "SNP Quality Analysis Tool",
+            "exe_file_name_base": "sqat",
             "project_root_dir" : "SQAT3Client",
             "owner": "GitEdvard",
             "deploy_root_path": r'c:\xxx\deploy'

--- a/tests/unit/sqat_tests/base.py
+++ b/tests/unit/sqat_tests/base.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from release_ccharp.apps.sqat import Application
+from release_ccharp.apps.common.directory_handling import AppPaths
 from tests.unit.utility.fake_windows_commands import FakeWindowsCommands
 from tests.unit.base import BaseTests
 
@@ -9,8 +10,8 @@ class SqatBaseTests(BaseTests):
         config = {
             "root_path": r'c:\xxx',
             "git_repo_name": "sqat",
-            "exe_file_name_base": "sqat",
-            "project_root_dir" : "sqat",
+            "exe_file_name_base": "SNP Quality Analysis Tool",
+            "project_root_dir" : "SQAT3Client",
             "owner": "GitEdvard",
             "deploy_root_path": r'c:\xxx\deploy'
         }

--- a/tests/unit/sqat_tests/base.py
+++ b/tests/unit/sqat_tests/base.py
@@ -1,0 +1,21 @@
+from __future__ import print_function
+from release_ccharp.apps.sqat import Application
+from tests.unit.utility.fake_windows_commands import FakeWindowsCommands
+from tests.unit.base import BaseTests
+
+
+class SqatBaseTests(BaseTests):
+    def setup_sqat(self):
+        config = {
+            "root_path": r'c:\xxx',
+            "git_repo_name": "sqat",
+            "exe_file_name_base": "sqat",
+            "project_root_dir" : "sqat",
+            "owner": "GitEdvard",
+            "deploy_root_path": r'c:\xxx\deploy'
+        }
+        wf, branch_provider, os_service = self.base_setup(config, 'sqat')
+        self.os_service = os_service
+        self.sqat = Application(wf, branch_provider, os_service,
+                                   FakeWindowsCommands(self.filesystem), whatif=False)
+

--- a/tests/unit/sqat_tests/sqat_build_tests.py
+++ b/tests/unit/sqat_tests/sqat_build_tests.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+from unittest import skip
+from release_ccharp.utils import create_dirs
+from release_ccharp.exceptions import SnpseqReleaseException
+from tests.unit.sqat_tests.base import SqatBaseTests
+
+
+class SqatBuildTests(SqatBaseTests):
+    def setUp(self):
+        self.setup_sqat()
+
+    def test_check_not_already_run__with_production_catalog_existing__throws(self):
+        # Arrange
+        create_dirs(self.os_service, r'c:\xxx\sqat\candidates\release-1.0.0\production')
+
+        # Act
+        # Assert
+        with self.assertRaises(SnpseqReleaseException):
+            self.sqat.builder.check_not_already_run()
+
+
+class FileBuilder:
+    def __init__(self, filesystem):
+        self.filesystem = filesystem
+

--- a/tests/unit/sqat_tests/sqat_build_tests.py
+++ b/tests/unit/sqat_tests/sqat_build_tests.py
@@ -57,6 +57,16 @@ line 3"""
                     'line 3')
         self.assertEqual(expected, c)
 
+    def test_find_solution_path(self):
+        # Arrange
+        self.file_builder.add_file_to_application_path('SQAT3.sln')
+
+        # Act
+        solution_file_path = self.sqat.builder.solution_file_path
+
+        # Assert
+        expected = r'c:\xxx\sqat\candidates\release-1.0.0\gitedvard-sqat-123\application\sqat3.sln'
+        self.assertEqual(expected, solution_file_path.lower())
 
 
 class FileBuilder:
@@ -65,6 +75,8 @@ class FileBuilder:
         self.os_service = os_service
         self.application_path = r'c:\xxx\sqat\candidates\release-1.0.0\GitEdvard-sqat-123\Application'
         self.project_root_path = r'c:\xxx\sqat\candidates\release-1.0.0\GitEdvard-sqat-123\Application\SQAT3Client'
+        create_dirs(os_service, self.application_path)
+        create_dirs(os_service, self.project_root_path)
 
     def add_file_to_application_path(self, filename='file.txt', contents=''):
         path = os.path.join(self.application_path, filename)

--- a/tests/unit/sqat_tests/sqat_build_tests.py
+++ b/tests/unit/sqat_tests/sqat_build_tests.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import os
 from unittest import skip
 from release_ccharp.utils import create_dirs
 from release_ccharp.exceptions import SnpseqReleaseException
@@ -8,6 +9,8 @@ from tests.unit.sqat_tests.base import SqatBaseTests
 class SqatBuildTests(SqatBaseTests):
     def setUp(self):
         self.setup_sqat()
+        self.file_builder = FileBuilder(self.filesystem, self.os_service)
+        create_dirs(self.os_service, self.file_builder.application_path)
 
     def test_check_not_already_run__with_production_catalog_existing__throws(self):
         # Arrange
@@ -18,8 +21,65 @@ class SqatBuildTests(SqatBaseTests):
         with self.assertRaises(SnpseqReleaseException):
             self.sqat.builder.check_not_already_run()
 
+    def test_update_binary_version_replace_strings__current_file_has_version_3_2__replaced_with_1_0(self):
+        s = """line1
+[assembly: AssemblyVersion("3.2.*")]
+line 3"""
+        (current, new) = self.sqat.builder.binary_version_updater.get_assembly_replace_strings(s, "1.0.0")
+        self.assertEqual("assembly: AssemblyVersion(\"3.2.*\")", current)
+        self.assertEqual("assembly: AssemblyVersion(\"1.0.0\")", new)
+
+    def test_assembly_file_path__with_initiation_as_reality__assembly_file_path_as_expected(self):
+        # Arrange
+        self.file_builder.add_file_to_project_root('AssemblyInfo.cs')
+        # Act
+        actual_assembly_info_path = self.sqat.builder._assembly_file_path.lower()
+
+        # Assert
+        expected = r'c:\xxx\sqat\candidates\release-1.0.0\gitedvard-sqat-123\application\sqat3client\assemblyinfo.cs'
+        self.assertEqual(expected, actual_assembly_info_path)
+
+    def test_binary_version_updater__with_assembly_file_has_version_3_2__replaced_with_1_0(self):
+        # Arrange
+        s = """line1
+[assembly: AssemblyVersion("3.2.*")]
+line 3"""
+        self.file_builder.add_file_to_project_root('AssemblyInfo.cs', contents=s)
+
+        # Act
+        self.sqat.builder.update_binary_version()
+
+        # Assert
+        file_path = os.path.join(self.file_builder.project_root_path, 'AssemblyInfo.cs')
+        c = self.file_builder.get_contents(file_path)
+        expected = ('line1\n'
+                    '[assembly: AssemblyVersion("1.0.0")]\n'
+                    'line 3')
+        self.assertEqual(expected, c)
+
+
 
 class FileBuilder:
-    def __init__(self, filesystem):
+    def __init__(self, filesystem, os_service):
         self.filesystem = filesystem
+        self.os_service = os_service
+        self.application_path = r'c:\xxx\sqat\candidates\release-1.0.0\GitEdvard-sqat-123\Application'
+        self.project_root_path = r'c:\xxx\sqat\candidates\release-1.0.0\GitEdvard-sqat-123\Application\SQAT3Client'
 
+    def add_file_to_application_path(self, filename='file.txt', contents=''):
+        path = os.path.join(self.application_path, filename)
+        self._log(path)
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def add_file_to_project_root(self, filename='file.txt', contents=''):
+        path = os.path.join(self.project_root_path, filename)
+        self._log(path)
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def _log(self, text):
+        print('add file into: {}'.format(text))
+
+    def get_contents(self, file_path):
+        with self.os_service.open(file_path, 'r') as f:
+            c = f.read()
+        return c

--- a/tests/unit/sqat_tests/sqat_build_tests.py
+++ b/tests/unit/sqat_tests/sqat_build_tests.py
@@ -68,6 +68,58 @@ line 3"""
         expected = r'c:\xxx\sqat\candidates\release-1.0.0\gitedvard-sqat-123\application\sqat3.sln'
         self.assertEqual(expected, solution_file_path.lower())
 
+    def test_move_candidates__with_exe_added_to_release__file_copied_to_production(self):
+        # Arrange
+        self.file_builder.add_file_to_project_root('SQATconfig.xml')
+        self.file_builder.add_file_to_project_root('SQATconnect.xml')
+        self.file_builder.add_file_to_release('sqat.exe')
+
+        # Act
+        self.sqat.builder.move_candidates()
+
+        # Assert
+        copied_file = r'c:\xxx\sqat\candidates\release-1.0.0\production\sqat.exe'
+        self.assertTrue(self.os_service.exists(copied_file))
+
+    def test_move_candidates__with_exe_added_to_release__file_copied_to_validation(self):
+        # Arrange
+        self.file_builder.add_file_to_project_root('SQATconfig.xml')
+        self.file_builder.add_file_to_project_root('SQATconnect.xml')
+        self.file_builder.add_file_to_release('sqat.exe')
+
+        # Act
+        self.sqat.builder.move_candidates()
+
+        # Assert
+        copied_file = r'c:\xxx\sqat\candidates\release-1.0.0\validation\sqat.exe'
+        self.assertTrue(self.os_service.exists(copied_file))
+
+    def test_move_candidates__with_config_file_added_to_project_root__file_copied_to_production(self):
+        # Arrange
+        self.file_builder.add_file_to_project_root('SQATconfig.xml')
+        self.file_builder.add_file_to_project_root('SQATconnect.xml')
+
+        # Act
+        self.sqat.builder.move_candidates()
+
+        # Assert
+        copied_file = r'c:\xxx\sqat\candidates\release-1.0.0\production\sqatconfig.xml'
+        self.assertTrue(self.os_service.exists(copied_file))
+
+    def test_move_candidates__with_connect_file_added_to_project_root__file_copied_to_production(self):
+        # Arrange
+        self.file_builder.add_file_to_project_root('SQATconfig.xml')
+        self.file_builder.add_file_to_project_root('SQATconnect.xml')
+
+        # Act
+        self.sqat.builder.move_candidates()
+
+        # Assert
+        copied_file = r'c:\xxx\sqat\candidates\release-1.0.0\production\sqatconnect.xml'
+        self.assertTrue(self.os_service.exists(copied_file))
+
+    def test_transform_config__with_validation_directory__orig_file_backed_up(self):
+        pass
 
 class FileBuilder:
     def __init__(self, filesystem, os_service):
@@ -75,8 +127,16 @@ class FileBuilder:
         self.os_service = os_service
         self.application_path = r'c:\xxx\sqat\candidates\release-1.0.0\GitEdvard-sqat-123\Application'
         self.project_root_path = r'c:\xxx\sqat\candidates\release-1.0.0\GitEdvard-sqat-123\Application\SQAT3Client'
+        self.release_path = \
+            r'c:\xxx\sqat\candidates\release-1.0.0\gitedvard-sqat-123\application\sqat3client\bin\release'
         create_dirs(os_service, self.application_path)
         create_dirs(os_service, self.project_root_path)
+        create_dirs(os_service, self.release_path)
+
+    def add_file_to_release(self, filename='file.txt', contents=''):
+        path = os.path.join(self.release_path, filename)
+        self._log(path)
+        self.filesystem.CreateFile(path, contents=contents)
 
     def add_file_to_application_path(self, filename='file.txt', contents=''):
         path = os.path.join(self.application_path, filename)

--- a/tests/unit/sqat_tests/sqat_build_tests.py
+++ b/tests/unit/sqat_tests/sqat_build_tests.py
@@ -220,6 +220,32 @@ line 3"""
             with self.assertRaises(SnpseqXmlEntryNotFoundException):
                 configXml.get_connection_string('QC_practice')
 
+    def test_copy_user_manual__user_manual_in_previous_candidate__user_manual_copied_to_production(self):
+        # Arrange
+        self.file_builder.add_file_in_previous_candidate('User Manual SNP Quality Analysis Tool.doc')
+        create_dirs(self.os_service, r'c:\xxx\sqat\candidates\release-1.0.0\production')
+
+        # Act
+        self.sqat.builder.copy_user_manual()
+
+        # Assert
+        expected_file = r'c:\xxx\sqat\candidates\release-1.0.0\production\User Manual SNP Quality Analysis Tool.doc'
+        self.assertTrue(self.os_service.exists(expected_file))
+
+    def test_copy_user_manual__user_manual_in_previous_candidate__user_manual_copied_to_current_candidate(self):
+        # Arrange
+        self.file_builder.add_file_in_previous_candidate('User Manual SNP Quality Analysis Tool.doc')
+        create_dirs(self.os_service, r'c:\xxx\sqat\candidates\release-1.0.0\production')
+
+        # Act
+        self.sqat.builder.copy_user_manual()
+
+        # Assert
+        expected_file = r'c:\xxx\sqat\candidates\release-1.0.0\User Manual SNP Quality Analysis Tool.doc'
+        self.assertTrue(self.os_service.exists(expected_file))
+
+
+
 class FileBuilder:
     def __init__(self, filesystem, os_service):
         self.filesystem = filesystem
@@ -258,6 +284,11 @@ class FileBuilder:
         path = os.path.join(self.project_root_path, filename)
         self._log(path)
         self.filesystem.CreateFile(path, contents=contents)
+
+    def add_file_in_previous_candidate(self, filename='file.txt', contents=''):
+        path = os.path.join(r'c:\xxx\sqat\candidates\release-0.0.9', filename)
+        self._log(path)
+        self.filesystem.CreateFile(path)
 
     def _log(self, text):
         print('add file into: {}'.format(text))

--- a/tests/unit/sqat_tests/sqat_config_xml_tests.py
+++ b/tests/unit/sqat_tests/sqat_config_xml_tests.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+import unittest
+from release_ccharp.apps.sqat_scripts.builder import SqatConfigXml
+from tests.unit.utility.config import SQAT_CONNECT
+from tests.unit.utility.fake_os_service import FakeOsService
+from tests.unit.sqat_tests.base import SqatBaseTests
+
+
+class SqatConfigXmlTests(SqatBaseTests):
+    def setUp(self):
+        self.setup_sqat()
+        self.connect_file_path = r'c:\xxx\connect.xml'
+        self.filesystem.CreateFile(self.connect_file_path, contents=SQAT_CONNECT)
+
+    def test_get_production_connection__with_original_connect_file__connection_string_achieved(self):
+        # Arrange
+        # Act
+        # Assert
+        with self.sqat.open_xml(self.connect_file_path) as xml:
+            configXml = SqatConfigXml(xml)
+            connection_string = configXml.get_connection_string('QC_1')
+            self.assertEqual('data source=mm-wchs001;integrated security=true;initial catalog=QC_1;',
+                             connection_string)
+
+    def test_get_production_connection__with_original_connect_file__chiasma_connection_string_achieved(self):
+        # Arrange
+        # Act
+        # Assert
+        with self.sqat.open_xml(self.connect_file_path) as xml:
+            configXml = SqatConfigXml(xml)
+            connection_string = configXml.get_chiasma_connection_string('QC_1')
+            self.assertEqual('data source=mm-wchs001;integrated security=true;initial catalog=GTDB2;',
+                             connection_string)

--- a/tests/unit/sqat_tests/sqat_deploy_tests.py
+++ b/tests/unit/sqat_tests/sqat_deploy_tests.py
@@ -1,0 +1,215 @@
+import os
+from unittest import skip
+from release_ccharp.apps.common.directory_handling import FileDoesNotExistsException
+from tests.unit.sqat_tests.base import SqatBaseTests
+
+
+class SqatDeployTests(SqatBaseTests):
+    def setUp(self):
+        self.setup_sqat()
+        self.file_builder = FileSystemBuilder(self.sqat, self.filesystem)
+
+    def add_required_files(self):
+        self.file_builder.add_file_in_production('sqat.exe')
+        self.file_builder.add_file_in_production('sqatconnect.xml')
+        self.file_builder.add_file_in_production('sqatconfig.xml')
+
+    def test_check_source_files__with_exe_lacking__throws(self):
+        # Arrange
+        #self.file_builder.add_file_in_production('sqat.exe')
+        self.file_builder.add_file_in_production('sqatconnect.xml')
+        self.file_builder.add_file_in_production('sqatconfig.xml')
+        # Act
+        # Assert
+        with self.assertRaises(FileDoesNotExistsException):
+            self.sqat.deployer.run()
+
+    def test_check_source_files__with_connect_file_lacking__throws(self):
+        # Arrange
+        self.file_builder.add_file_in_production('sqat.exe')
+        #self.file_builder.add_file_in_production('sqatconnect.xml')
+        self.file_builder.add_file_in_production('sqatconfig.xml')
+        # Act
+        # Assert
+        with self.assertRaises(FileDoesNotExistsException):
+            self.sqat.deployer.run()
+
+    def test_check_source_files__with_config_file_lacking__throws(self):
+        # Arrange
+        self.file_builder.add_file_in_production('sqat.exe')
+        self.file_builder.add_file_in_production('sqatconnect.xml')
+        #self.file_builder.add_file_in_production('sqatconfig.xml')
+        # Act
+        # Assert
+        with self.assertRaises(FileDoesNotExistsException):
+            self.sqat.deployer.run()
+
+    def test_move_files__with_three_files_in_production__files_exists_in_deploy_catalog(self):
+        # Arrange
+        self.add_required_files()
+        # Act
+        self.sqat.deployer.file_deployer.move_deploy_files()
+        # Assert
+        exe_path = r'c:\xxx\deploy\sqat.exe'
+        config = r'c:\xxx\deploy\sqatconfig.xml'
+        connect = r'c:\xxx\deploy\sqatconnect.xml'
+        self.assertTrue(self.os_module.path.exists(exe_path))
+        self.assertTrue(self.os_module.path.exists(config))
+        self.assertTrue(self.os_module.path.exists(connect))
+
+    def test_move_release_history__release_history_exists__release_history_moved(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_file_in_latest_candidate_dir(r'release-history.txt')
+        # Act
+        self.sqat.deployer.file_deployer.copy_release_history()
+        # Assert
+        release_history = r'c:\xxx\sqat\doc\release-history.txt'
+        self.assertTrue(self.os_module.path.exists(release_history))
+
+    def test_archive_version__with_validation_files_and_sql_script__validation_file_in_archive_folder(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        # Act
+        self.sqat.deployer.move_to_archive()
+        # Assert
+        archived_validation_file = \
+            r'c:\xxx\sqat\uservalidations\allversions\1.0.0\validationfiles\validationfile.txt'
+        self.assertTrue(self.os_module.path.exists(archived_validation_file))
+
+    def test_archive_version__with_validation_files_and_sql_script__validation_files_removed_from_latest(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        # Act
+        self.sqat.deployer.move_to_archive()
+        # Assert
+        validation_dir_in_latest = \
+            r'c:\xxx\sqat\uservalidations\latest\validationfiles'
+        self.assertFalse(self.os_module.path.exists(validation_dir_in_latest))
+
+    def test_archive_version__with_validation_files_and_sql_script__validation_file_removed_from_next(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_validation_file_in_next(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        # Act
+        self.sqat.deployer.move_to_archive()
+        # Assert
+        path_to_validation_in_next = \
+            r'c:\xxx\sqat\uservalidations\allversions\_next_release\validationfiles\validationfile.txt'
+        self.assertFalse(self.os_module.path.exists(path_to_validation_in_next))
+
+    def test_archive_version__with_validation_files_and_sql_script__shortcut_in_archive_folder(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        # Act
+        self.sqat.deployer.move_to_archive()
+        # Assert
+        archived_shortcut = \
+            r'c:\xxx\sqat\uservalidations\allversions\1.0.0\sqat.lnk'
+        self.assertTrue(self.os_module.path.exists(archived_shortcut))
+
+    def test_archive_version__with_validation_files_and_sql_script__shortcut_remains_in_latest(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        # Act
+        self.sqat.deployer.move_to_archive()
+        # Assert
+        shortcut_in_latest = \
+            r'c:\xxx\sqat\uservalidations\latest\sqat.lnk'
+        self.assertTrue(self.os_module.path.exists(shortcut_in_latest))
+
+    def test_archive_version__with_validation_files_and_sql_script__shortcut_target_correct_in_latest(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        # Act
+        self.sqat.deployer.move_to_archive()
+        # Assert
+        shortcut_in_latest = \
+            r'c:\xxx\sqat\uservalidations\latest\sqat.lnk'
+        shortcut_target = self.sqat.validation_deployer.shortcut_examiner.\
+            _extract_shortcut_target(shortcut_in_latest)
+        self.assertEqual(r'c:\xxx\sqat\candidates\release-1.0.0\validation\sqat.exe', shortcut_target)
+
+    def test_archive_version__with_validation_files_and_sql_script__sql_script_in_archive_folder(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        # Act
+        self.sqat.deployer.move_to_archive()
+        # Assert
+        archived_script = \
+            r'c:\xxx\sqat\uservalidations\allversions\1.0.0\sqlupdates\script1.sql'
+        self.assertTrue(self.os_module.path.exists(archived_script))
+
+    def test_archive_version__with_validation_files_and_sql_script__sql_script_removed_from_next(self):
+        # Arrange
+        self.add_required_files()
+        self.file_builder.add_validation_file_in_latest(r'validationfile.txt')
+        self.file_builder.add_sql_script_in_next(r'script1.sql')
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        # Act
+        self.sqat.deployer.move_to_archive()
+        # Assert
+        script_path_in_next = \
+            r'c:\xxx\sqat\uservalidations\allversions\_next_release\sqlupdates\script1.sql'
+        self.assertFalse(self.os_module.path.exists(script_path_in_next))
+
+
+class FileSystemBuilder:
+    def __init__(self, sqat, filesystem):
+        self.sqat = sqat
+        self.filesystem = filesystem
+
+    def add_file_in_production(self, filename='filename.txt'):
+        path = os.path.join(self.sqat.app_paths.production_dir, filename)
+        self.filesystem.CreateFile(path)
+
+    def add_file_in_production_config_lab(self, filename='file.txt'):
+        path = os.path.join(self.sqat.app_paths.production_config_lab_dir, filename)
+        self.filesystem.CreateFile(path)
+
+    def add_file_in_current_candidate_dir(self, filename='file.txt'):
+        path = os.path.join(self.sqat.path_properties.current_candidate_dir, filename)
+        self.filesystem.CreateFile(path)
+
+    def add_file_in_latest_candidate_dir(self, filename='file.txt'):
+        path = os.path.join(self.sqat.path_properties.latest_accepted_candidate_dir, filename)
+        print('add file into: {}'.format(path))
+        self.filesystem.CreateFile(path)
+
+    def add_validation_file_in_latest(self, filename='validationfile.txt', contents=''):
+        path = os.path.join(self.sqat.path_properties.latest_validation_files, filename)
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def add_validation_file_in_next(self, filename='validationfile.txt', contents=''):
+        path = os.path.join(self.sqat.path_properties.next_validation_files, filename)
+        print('add file into: {}'.format(path))
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def add_sql_script_in_next(self, filename='script1.sql', contents=''):
+        path = os.path.join(self.sqat.path_properties.next_sql_updates, filename)
+        print('add file into: {}'.format(path))
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def add_shortcut(self, candidate_dir='release-1.0.0'):
+        cand_path = os.path.join(self.sqat.path_properties.root_candidates, candidate_dir)
+        current_shortcut_target = os.path.join(cand_path, r'buildpath\sqat.exe')
+        shortcut_save_path = os.path.join(self.sqat.path_properties.user_validations_latest, r'sqat.lnk')
+        self.sqat.windows_commands.create_shortcut(shortcut_save_path, current_shortcut_target)

--- a/tests/unit/sqat_tests/sqat_deploy_validation_tests.py
+++ b/tests/unit/sqat_tests/sqat_deploy_validation_tests.py
@@ -15,7 +15,7 @@ class SqatDeployValidationTests(SqatBaseTests):
         dest_shortcut_path = r'c:\xxx\sqat\uservalidations\latest\sqat.lnk'
 
         # Act
-        self.sqat.validation_deployer.run()
+        self.sqat.validation_deployer.path_actions.create_shortcut_to_exe()
         shortcut_target = self.sqat.validation_deployer.shortcut_examiner.\
             _extract_shortcut_target(dest_shortcut_path)
 
@@ -176,6 +176,7 @@ class SqatDeployValidationTests(SqatBaseTests):
         dir_objects = [o for o in self.sqat.os_service.listdir(latest)]
         self.assertEqual(2, len(dir_objects))
 
+
 class FileSystemBuilder:
     def __init__(self, sqat, filesystem):
         self.sqat = sqat
@@ -213,3 +214,6 @@ class FileSystemBuilder:
         with self.sqat.os_service.open(path, 'r') as f:
             c = f.read()
         return c
+
+    def _log(self, path):
+        print('add file into: {}'.format(path))

--- a/tests/unit/sqat_tests/sqat_deploy_validation_tests.py
+++ b/tests/unit/sqat_tests/sqat_deploy_validation_tests.py
@@ -1,0 +1,215 @@
+from __future__ import print_function
+import os
+from tests.unit.sqat_tests.base import SqatBaseTests
+
+
+class SqatDeployValidationTests(SqatBaseTests):
+    def setUp(self):
+        self.setup_sqat()
+        self.file_builder = FileSystemBuilder(self.sqat, self.filesystem)
+
+    def test_create_shortcut__with_target_exists_in_candidates__extract_shortcut_target_works(self):
+        # Arrange
+        fake_target_path = r'c:\xxx\sqat\candidates\release-1.0.0\validation\sqat.exe'
+        self.filesystem.CreateFile(fake_target_path)
+        dest_shortcut_path = r'c:\xxx\sqat\uservalidations\latest\sqat.lnk'
+
+        # Act
+        self.sqat.validation_deployer.run()
+        shortcut_target = self.sqat.validation_deployer.shortcut_examiner.\
+            _extract_shortcut_target(dest_shortcut_path)
+
+        #Assert
+        self.assertEqual(r'c:\xxx\sqat\candidates\release-1.0.0\validation\sqat.exe', shortcut_target)
+
+    def test_copy_from_next__with_latest_dir_empty__copied_files_exists_in_latest(self):
+        # Arrange
+        validation_file = \
+            r'c:\xxx\sqat\uservalidations\allversions\_next_release\validationfiles\validation_file.txt'
+        self.filesystem.CreateFile(validation_file)
+        self.file_builder.add_shortcut()
+
+        # Act
+        self.sqat.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\sqat\uservalidations\latest\validationfiles\validation_file.txt'
+        self.assertTrue(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_branch_and_shortcut_different__validation_files_copied_latest_to_archive(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_latest('old_validation_file.txt')
+        self.file_builder.add_validation_file_in_next('new_validation_file.txt')
+
+        # Act
+        self.sqat.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\sqat\uservalidations\allversions\0.1.0\validationfiles\old_validation_file.txt'
+        self.assertTrue(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_branch_and_shortcut_different__shortcut_copied_to_archive(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_latest('old_validation_file.txt')
+        self.file_builder.add_validation_file_in_next('new_validation_file.txt')
+
+        # Act
+        self.sqat.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\sqat\uservalidations\allversions\0.1.0\sqat.lnk'
+        self.assertTrue(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_branch_and_shortcut_different__sql_script_not_copied_to_archive(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_latest('old_validation_file.txt')
+        self.file_builder.add_validation_file_in_next('new_validation_file.txt')
+        self.file_builder.add_sql_script_in_next('script1.sql')
+
+        # Act
+        self.sqat.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\sqat\uservalidations\allversions\0.1.0\sqlupdates\script1.sql'
+        self.assertFalse(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_branch_and_shortcut_different__file_deleted_in_latest(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_latest('old_validation_file.txt')
+        self.file_builder.add_validation_file_in_next('new_validation_file.txt')
+
+        # Act
+        self.sqat.validation_deployer.copy_validation_files()
+
+        # Assert
+        old_file = r'c:\xxx\sqat\uservalidations\latest\validationfiles\old_validation_file.txt'
+        self.assertFalse(self.os_module.path.exists(old_file))
+
+    def test_copy_from_next__with_branch_and_shortcut_same__validation_files_not_copied_to_archive(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        self.file_builder.add_validation_file_in_latest('old_validation_file.txt')
+        self.file_builder.add_validation_file_in_next('new_validation_file.txt')
+
+        # Act
+        self.sqat.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\sqat\uservalidations\allversions\1.0.0\validationfiles\old_validation_file.txt'
+        self.assertFalse(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_file_in_archive__file_exists_in_latest(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_archive('validation_file.txt')
+
+        # Act
+        self.sqat.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\sqat\uservalidations\latest\validationfiles\validation_file.txt'
+        self.assertTrue(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_file_in_archive__file_removed_in_archive(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_archive('validation_file.txt')
+
+        # Act
+        self.sqat.validation_deployer.copy_validation_files()
+
+        # Assert
+        source_file = r'c:\xxx\sqat\uservalidations\allversions\1.0.0\validationfiles\validation_file.txt'
+        self.assertFalse(self.os_module.path.exists(source_file))
+
+    def test_copy_from_next__with_file_in_archive__file_from_next_in_latest(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_archive('validation_file.txt')
+        self.file_builder.add_validation_file_in_next('file_from_next.txt')
+
+        # Act
+        self.sqat.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\sqat\uservalidations\latest\validationfiles\file_from_next.txt'
+        self.assertTrue(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__with_same_file_in_next_and_archive__archive_file_in_latest(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-0.1.0')
+        self.file_builder.add_validation_file_in_archive('validation_file.txt', contents='archive')
+        self.file_builder.add_validation_file_in_next('validation_file.txt', contents='next')
+
+        # Act
+        self.sqat.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\sqat\uservalidations\latest\validationfiles\validation_file.txt'
+        self.assertEqual('archive', self.file_builder.get_contents(copied_file))
+
+    def test_copy_from_next__shortcut_nonexistent_in_latest__plain_copy(self):
+        # Arrange
+        self.file_builder.add_validation_file_in_next('validation_file.txt')
+
+        # Act
+        self.sqat.validation_deployer.copy_validation_files()
+
+        # Assert
+        copied_file = r'c:\xxx\sqat\uservalidations\latest\validationfiles\validation_file.txt'
+        self.assertTrue(self.os_module.path.exists(copied_file))
+
+    def test_copy_from_next__ordinary_setup__only_one_catalog_and_shortcut_in_latest(self):
+        # Arrange
+        self.file_builder.add_shortcut(candidate_dir='release-1.0.0')
+        self.file_builder.add_validation_file_in_next('validation_file.txt')
+
+        # Act
+        self.sqat.validation_deployer.copy_validation_files()
+
+        # Assert
+        latest = r'c:\xxx\sqat\uservalidations\latest'
+        dir_objects = [o for o in self.sqat.os_service.listdir(latest)]
+        self.assertEqual(2, len(dir_objects))
+
+class FileSystemBuilder:
+    def __init__(self, sqat, filesystem):
+        self.sqat = sqat
+        self.filesystem = filesystem
+
+    def add_shortcut(self, candidate_dir='release-1.0.0'):
+        cand_path = os.path.join(self.sqat.path_properties.root_candidates, candidate_dir)
+        current_shortcut_target = os.path.join(cand_path, r'buildpath\sqat.exe')
+        shortcut_save_path = os.path.join(self.sqat.path_properties.user_validations_latest, r'sqat.lnk')
+        self.sqat.windows_commands.create_shortcut(shortcut_save_path, current_shortcut_target)
+
+    def add_validation_file_in_latest(self, filename='validationfile.txt', contents=''):
+        path = os.path.join(self.sqat.path_properties.latest_validation_files, filename)
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def add_validation_file_in_next(self, filename='validationfile.txt', contents=''):
+        path = os.path.join(self.sqat.path_properties.next_validation_files, filename)
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def add_sql_script_in_next(self, filename='script1.sql', contents=''):
+        path = os.path.join(self.sqat.path_properties.next_sql_updates, filename)
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def add_validation_file_in_archive(self, filename='validationfile.txt', contents=''):
+        """
+        Put it in folder matching the candidate version
+        :param filename:
+        :return:
+        """
+        path = os.path.join(self.sqat.path_properties.archive_dir_validation_files, filename)
+        self.filesystem.CreateFile(path, contents=contents)
+
+    def get_contents(self, path):
+        c = None
+        with self.sqat.os_service.open(path, 'r') as f:
+            c = f.read()
+        return c

--- a/tests/unit/utility/SQATconnect.xml
+++ b/tests/unit/utility/SQATconnect.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" standalone="yes"?>
+<Connections>
+  <Connection>
+    <Name>QC_1</Name>
+    <ConnectionString>data source=mm-wchs001;integrated security=true;initial catalog=QC_1;</ConnectionString>
+    <ChiasmaConnectionString>data source=mm-wchs001;integrated security=true;initial catalog=GTDB2;</ChiasmaConnectionString>
+  </Connection>
+  <Connection>
+    <Name>QC_devel</Name>
+    <ConnectionString>data source=mm-wchs001;integrated security=true;initial catalog=QC_devel;</ConnectionString>
+    <ChiasmaConnectionString>data source=mm-wchs001;integrated security=true;initial catalog=GTDB2_devel;</ChiasmaConnectionString>
+  </Connection>
+  <Connection>
+    <Name>QC_practice</Name>
+    <ConnectionString>data source=mm-wchs001;integrated security=true;initial catalog=QC_practice;</ConnectionString>
+    <ChiasmaConnectionString>data source=mm-wchs001;integrated security=true;initial catalog=GTDB2_practice;</ChiasmaConnectionString>
+  </Connection>
+</Connections>

--- a/tests/unit/utility/config.py
+++ b/tests/unit/utility/config.py
@@ -7,4 +7,13 @@ def load_chiasma_config():
         content = f.read()
     return content
 
+def load_sqat_connect():
+    here = os.path.dirname(__file__)
+    with open(os.path.join(here, 'SQATconnect.xml'), 'r') as f:
+        content = f.read()
+    return content
+
+
 CHIASMA_CONFIG = load_chiasma_config()
+
+SQAT_CONNECT = load_sqat_connect()

--- a/tests/unit/utility/fake_os_service.py
+++ b/tests/unit/utility/fake_os_service.py
@@ -1,3 +1,4 @@
+import StringIO
 from pyfakefs.fake_filesystem import FakeOsModule
 from pyfakefs.fake_filesystem_shutil import FakeShutilModule
 from pyfakefs.fake_filesystem import FakeFileOpen
@@ -50,9 +51,15 @@ class FakeOsService:
     def open(self, path, mode):
         file_module = FakeFileOpen(self.filesystem)
 
-        def read():
+        if 'r' in mode:
             with file_module(path) as file_object:
-                return "".join([line for line in file_object])
+                c = "".join([line for line in file_object])
+            mybuffer = StringIO.StringIO()
+            mybuffer.write(c)
+            mybuffer.seek(0)
+
+        def read(n=-1):
+            return mybuffer.read(n)
 
         def write(text):
             if self.exists(path):

--- a/tests/unit/utils_tests.py
+++ b/tests/unit/utils_tests.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest import skip
 import os
+import StringIO
 from pyfakefs import fake_filesystem
 from release_ccharp.utils import copytree_preserve_existing
 from release_ccharp.utils import copytree_replace_existing
@@ -382,6 +383,43 @@ class TestTestIterator(unittest.TestCase):
         lst = list(it)
 
         self.assertEqual(5, len(lst))
+
+
+class TestStreamHandling(unittest.TestCase):
+    def setUp(self):
+        self.filesystem = fake_filesystem.FakeFilesystem()
+        self.os_service = FakeOsService(self.filesystem)
+        self.source = r'c:\src'
+        create_dirs(self.os_service, self.source)
+
+
+    def test_stringio__call_read__returns_string(self):
+        buffer = StringIO.StringIO()
+        buffer.write('hej')
+        buffer.seek(0)
+        c = buffer.read()
+        self.assertEqual('hej', c)
+
+    def test_stringio__call_read_n_one_time__returns_first_n_chars(self):
+        buffer = StringIO.StringIO()
+        buffer.write('hej')
+        buffer.seek(0)
+        c = buffer.read(2)
+        self.assertEqual('he', c)
+
+    def test_stringio__call_read_n_two_times__returns_second_chunk_of_chars(self):
+        buffer = StringIO.StringIO()
+        buffer.write('hej')
+        buffer.seek(0)
+        c = buffer.read(2)
+        c = buffer.read(2)
+        self.assertEqual('j', c)
+
+    def test_fake_os_service_open__with_fake_file_with_contents__contents_is_read(self):
+        self.filesystem.CreateFile(r'c:\src\file.txt', contents='contents')
+        with self.os_service.open(r'c:\src\file.txt', 'r') as f:
+            c = f.read()
+        self.assertEqual('contents', c)
 
 
 class FileSystemBuilder():


### PR DESCRIPTION
Implement build, deploy-validation and deploy for SQAT. 

These things differ in sqat compared to chiasma:
* Internal paths in code tree is somewhat different. E.g. 
** AssemblyInfo file not in properties, 
** solution file not directly under the root dir. 

Implementation
* Add class SqatConfigXml, to be used instead of StandardVSConfigXml
* 

Refactorings:
* Refactor unit tests, add a base class for unit tests for basic setup.  (generate folder tree)
* fake os service -> read, use StringIO to produce a stream made of a string. 
* Update binary version, have assembly file path as input argument. 
* app_paths -> move candidates, have input argument for project root dir. 
* 