### PR TITLE
chi-882, fp txt config file remains in latest after deploy

### DIFF
--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -166,6 +166,11 @@ class FileDeployer:
         self.os_service.copyfile(src_release_history, dst)
         print('ok')
 
+    def copy_file(self, filename, src_dir, dst_dir):
+        src = os.path.join(src_dir, filename)
+        dst = os.path.join(dst_dir, filename)
+        self.os_service.copyfile(src, dst)
+
     def check_not_already_run(self):
         if self.os_service.exists(self.app_paths.production_dir) or \
                 self.os_service.exists(self.app_paths.validation_dir):

--- a/release_ccharp/apps/fp_scripts/deployer.py
+++ b/release_ccharp/apps/fp_scripts/deployer.py
@@ -35,5 +35,11 @@ class FPDeployer:
         self.file_deployer.move_latest_to_archive(str(self.branch_provider.candidate_version))
         self.file_deployer.move_sql_scripts_to_archive(str(self.branch_provider.candidate_version))
         self.path_actions.create_shortcut_to_exe()
+        self.copy_config_file()
         delete_directory_contents(self.os_service, self.path_properties.next_validation_files)
         print('ok')
+
+    def copy_config_file(self):
+        self.file_deployer.copy_file('FPDatabaseConfig.txt',
+                                     self.file_deployer.app_paths.validation_dir,
+                                     self.path_properties.user_validations_latest)

--- a/release_ccharp/apps/fp_scripts/validation_deployer.py
+++ b/release_ccharp/apps/fp_scripts/validation_deployer.py
@@ -29,7 +29,7 @@ class FPValidationDeployer:
         self.file_deployer.copy_to_latest()
 
     def copy_config_file(self):
-        src = os.path.join(self.file_deployer.app_paths.validation_dir, 'FPDatabaseConfig.txt')
-        dst = os.path.join(self.path_properties.user_validations_latest, 'FPDatabaseConfig.txt')
-        self.os_service.copyfile(src, dst)
+        self.file_deployer.copy_file('FPDatabaseConfig.txt',
+                                     self.file_deployer.app_paths.validation_dir,
+                                     self.path_properties.user_validations_latest)
 

--- a/tests/unit/fp_tests/fp_deploy_tests.py
+++ b/tests/unit/fp_tests/fp_deploy_tests.py
@@ -70,6 +70,20 @@ class ChiasmaDeployTests(FPBaseTests):
         with self.assertRaises(FileDoesNotExistsException):
             self.fp.deployer.run()
 
+    def test_run__with_txt_config_in_validation__txt_config_exists_in_latest(self):
+        # Arrange
+        self.file_builder.add_file_in_production('fpdatabase.exe')
+        self.file_builder.add_file_in_production('fpdatabase.exe.config')
+        self.file_builder.add_file_in_production('fpdatabaseconfig.txt')
+        self.file_builder.add_file_in_validation('fpdatabaseconfig.txt')
+
+        # Act
+        self.fp.deployer.run()
+
+        # Assert
+        configpath = r'c:\xxx\fp\uservalidations\latest\fpdatabaseconfig.txt'
+        self.assertTrue(self.os_service.exists(configpath))
+
 
 class FileSystemBuilder:
     def __init__(self, fp, filesystem):
@@ -80,35 +94,6 @@ class FileSystemBuilder:
         path = os.path.join(self.fp.app_paths.production_dir, filename)
         self.filesystem.CreateFile(path)
 
-    def add_file_in_production_config_lab(self, filename='file.txt'):
-        path = os.path.join(self.fp.app_paths.production_config_lab_dir, filename)
+    def add_file_in_validation(self, filename='filename.txt'):
+        path = os.path.join(self.fp.app_paths.validation_dir, filename)
         self.filesystem.CreateFile(path)
-
-    def add_file_in_current_candidate_dir(self, filename='file.txt'):
-        path = os.path.join(self.fp.path_properties.current_candidate_dir, filename)
-        self.filesystem.CreateFile(path)
-
-    def add_file_in_latest_candidate_dir(self, filename='file.txt'):
-        path = os.path.join(self.fp.path_properties.latest_accepted_candidate_dir, filename)
-        print('add file into: {}'.format(path))
-        self.filesystem.CreateFile(path)
-
-    def add_validation_file_in_latest(self, filename='validationfile.txt', contents=''):
-        path = os.path.join(self.fp.path_properties.latest_validation_files, filename)
-        self.filesystem.CreateFile(path, contents=contents)
-
-    def add_validation_file_in_next(self, filename='validationfile.txt', contents=''):
-        path = os.path.join(self.fp.path_properties.next_validation_files, filename)
-        print('add file into: {}'.format(path))
-        self.filesystem.CreateFile(path, contents=contents)
-
-    def add_sql_script_in_next(self, filename='script1.sql', contents=''):
-        path = os.path.join(self.fp.path_properties.next_sql_updates, filename)
-        print('add file into: {}'.format(path))
-        self.filesystem.CreateFile(path, contents=contents)
-
-    def add_shortcut(self, candidate_dir='release-1.0.0'):
-        cand_path = os.path.join(self.fp.path_properties.root_candidates, candidate_dir)
-        current_shortcut_target = os.path.join(cand_path, r'buildpath\fpdatabase.exe')
-        shortcut_save_path = os.path.join(self.fp.path_properties.user_validations_latest, r'fpdatabase.lnk')
-        self.fp.windows_commands.create_shortcut(shortcut_save_path, current_shortcut_target)


### PR DESCRIPTION
When deploy command is issued, all contents in latest is removed. Now
the txt config file is also copied to latest after deploy, in order for
the shortcut to work.

Refactorings:
Add copy_file() to file_deployer, and call it from both deploy_validation and deploy, for fp-scripts. 

Remove redundant code in fp_tests