### PR TITLE
Chi 726 copy db backup

### DIFF
--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -38,9 +38,9 @@ class Application(ApplicationBase):
         super(Application, self).deploy_validation()
         self.validation_deployer.run()
 
-    def deploy(self):
-        super(Application, self).deploy()
-        self.deployer.run()
+    def deploy(self, skip_copy_backup):
+        super(Application, self).deploy(skip_copy_backup)
+        self.deployer.run(skip_copy_backup)
 
     def download_release_history(self):
         super(Application, self).download_release_history()

--- a/release_ccharp/apps/chiasma.py
+++ b/release_ccharp/apps/chiasma.py
@@ -28,7 +28,7 @@ class Application(ApplicationBase):
         self.validation_deployer = ChiasmaValidationDeployer(
             self, file_deployer, path_actions)
         self.deployer = ChiasmaDeployer(
-            self.path_properties, file_deployer, path_actions, os_service, branch_provider)
+            self.path_properties, file_deployer, path_actions, branch_provider)
 
     def build(self):
         super(Application, self).build()

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -4,12 +4,11 @@ from release_ccharp.apps.common.base import LogMixin
 
 
 class ChiasmaDeployer(LogMixin):
-    def __init__(self, path_properties, file_deployer, path_actions, os_service, branch_provider):
+    def __init__(self, path_properties, file_deployer, path_actions, branch_provider):
         self.path_properties = path_properties
         self.file_deployer = file_deployer
         self.branch_provider = branch_provider
         self.path_actions = path_actions
-        self.os_service = os_service
 
     def run(self):
         self.execute_and_log(self.check_source_files_exists)
@@ -35,4 +34,4 @@ class ChiasmaDeployer(LogMixin):
         self.file_deployer.move_latest_to_archive(str(self.branch_provider.candidate_version))
         self.file_deployer.move_sql_scripts_to_archive(str(self.branch_provider.candidate_version))
         self.path_actions.create_shortcut_to_exe()
-        delete_directory_contents(self.os_service, self.path_properties.next_validation_files)
+        self.file_deployer.delete_directory_contents(self.path_properties.next_validation_files)

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -10,11 +10,13 @@ class ChiasmaDeployer(LogMixin):
         self.branch_provider = branch_provider
         self.path_actions = path_actions
 
-    def run(self):
+    def run(self, skip_copy_backup=False):
         self.execute_and_log(self.check_source_files_exists)
         self.file_deployer.move_deploy_files()
         self.file_deployer.move_user_manual()
         self.execute_and_log(self.move_to_archive, 'Move validation files and sql script to archive...')
+        if not skip_copy_backup:
+            self.execute_and_log(self.copy_backup, 'Copy backup of devel db to current candidate...')
 
     def check_source_files_exists(self):
         self.file_deployer.check_exe_file_exists()

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -35,3 +35,16 @@ class ChiasmaDeployer(LogMixin):
         self.file_deployer.move_sql_scripts_to_archive(str(self.branch_provider.candidate_version))
         self.path_actions.create_shortcut_to_exe()
         self.file_deployer.delete_directory_contents(self.path_properties.next_validation_files)
+
+    def copy_backup(self):
+        backup_dir = self.path_properties.db_backup_server_dir
+        filename = self.path_properties.db_backup_filename
+        try:
+            self.file_deployer.copy_file(filename,
+                                         backup_dir,
+                                         self.path_properties.current_candidate_dir)
+        except IOError as e:
+            msg = 'Backup file on server could not be found. Either you have not access to the path, or ' \
+                  'the config file referes to a non existent path. Use option --skip_copy_backup if needed. Original ' \
+                  'error message: {}'.format(str(e))
+            raise IOError(msg)

--- a/release_ccharp/apps/chiasma_scripts/deployer.py
+++ b/release_ccharp/apps/chiasma_scripts/deployer.py
@@ -1,8 +1,9 @@
 from __future__ import print_function
 from release_ccharp.utils import delete_directory_contents
+from release_ccharp.apps.common.base import LogMixin
 
 
-class ChiasmaDeployer:
+class ChiasmaDeployer(LogMixin):
     def __init__(self, path_properties, file_deployer, path_actions, os_service, branch_provider):
         self.path_properties = path_properties
         self.file_deployer = file_deployer
@@ -11,20 +12,16 @@ class ChiasmaDeployer:
         self.os_service = os_service
 
     def run(self):
-        self.check_source_files_exists()
+        self.execute_and_log(self.check_source_files_exists)
         self.file_deployer.move_deploy_files()
         self.file_deployer.move_user_manual()
-        self.move_to_archive()
+        self.execute_and_log(self.move_to_archive, 'Move validation files and sql script to archive...')
 
     def check_source_files_exists(self):
-        print('Check that source files exists ...')
-
         self.file_deployer.check_exe_file_exists()
         self.file_deployer.check_config_file_exists()
         self.file_deployer.check_config_lab_file_exists()
         self.file_deployer.check_user_manual_exists()
-
-        print('ok')
 
     def copy_release_history(self):
         self.file_deployer.copy_release_history()
@@ -35,9 +32,7 @@ class ChiasmaDeployer:
         This method have to be called before the candidate version is accepted.
         :return:
         """
-        print('Move validation files and sql script to archive...')
         self.file_deployer.move_latest_to_archive(str(self.branch_provider.candidate_version))
         self.file_deployer.move_sql_scripts_to_archive(str(self.branch_provider.candidate_version))
         self.path_actions.create_shortcut_to_exe()
         delete_directory_contents(self.os_service, self.path_properties.next_validation_files)
-        print('ok')

--- a/release_ccharp/apps/common/base.py
+++ b/release_ccharp/apps/common/base.py
@@ -47,7 +47,7 @@ class ApplicationBase(object):
         print('Starting deploy validation')
 
     @abc.abstractmethod
-    def deploy(self):
+    def deploy(self, skip_copy_backup):
         print('Starting deploy')
 
     @abc.abstractmethod

--- a/release_ccharp/apps/common/base.py
+++ b/release_ccharp/apps/common/base.py
@@ -98,3 +98,11 @@ class LatestVersionExaminer:
     @abc.abstractmethod
     def is_candidate_in_latest(self):
         pass
+
+
+class LogMixin:
+    def execute_and_log(self, fcn, message=None):
+        msg = message or '{}...'.format(fcn.__name__.replace('_', ' '))
+        print(msg)
+        fcn()
+        print('ok')

--- a/release_ccharp/apps/common/directory_handling.py
+++ b/release_ccharp/apps/common/directory_handling.py
@@ -178,6 +178,9 @@ class FileDeployer:
                 ("Production or validation catalog already exists. " 
                 "They need to be removed before continuing"))
 
+    def delete_directory_contents(self, target_dir):
+        delete_directory_contents(self.os_service, target_dir)
+
 
 class FileDoesNotExistsException(Exception):
     pass

--- a/release_ccharp/apps/fp.py
+++ b/release_ccharp/apps/fp.py
@@ -34,8 +34,8 @@ class Application(ApplicationBase):
         super(Application, self).deploy_validation()
         self.validation_deployer.run()
 
-    def deploy(self):
-        super(Application, self).deploy()
+    def deploy(self, skip_copy_backup):
+        super(Application, self).deploy(skip_copy_backup)
         self.deployer.run()
 
     def download_release_history(self):

--- a/release_ccharp/apps/sqat.py
+++ b/release_ccharp/apps/sqat.py
@@ -43,8 +43,8 @@ class Application(ApplicationBase):
         super(Application, self).deploy_validation()
         self.validation_deployer.run()
 
-    def deploy(self):
-        super(Application, self).deploy()
+    def deploy(self, skip_copy_backup):
+        super(Application, self).deploy(skip_copy_backup)
         self.deployer.run()
 
     def download_release_history(self):

--- a/release_ccharp/apps/testing_repo.py
+++ b/release_ccharp/apps/testing_repo.py
@@ -28,17 +28,17 @@ class Application(ApplicationBase):
             branch_provider=branch_provider, app_paths=self.app_paths, os_service=os_service)
         file_deployer = FileDeployer(
             self.path_properties, self.os_service, snpseq_workflow.config, self.app_paths)
-        self.fp_builder = FPBuilder(self, file_deployer, self.app_paths, self.config, os_service, windows_commands)
+        self.chiasma_builder = ChiasmaBuilder(self, file_deployer, self.app_paths, self.config)
         path_actions = SnpseqPathActions(
             whatif, self.path_properties, os_service, self.app_paths, self.windows_commands)
-        self.validation_deployer = FPValidationDeployer(
-            self, file_deployer, path_actions, os_service, branch_provider, windows_commands, self.path_properties)
-        self.deployer = FPDeployer(
+        self.validation_deployer = ChiasmaValidationDeployer(
+            self, file_deployer, path_actions)
+        self.deployer = ChiasmaDeployer(
             self.path_properties, file_deployer, path_actions, os_service, branch_provider)
 
     def build(self):
         super(Application, self).build()
-        self.fp_builder.run()
+        self.chiasma_builder.run()
 
     def deploy_validation(self):
         super(Application, self).deploy_validation()

--- a/release_ccharp/apps/testing_repo.py
+++ b/release_ccharp/apps/testing_repo.py
@@ -34,7 +34,7 @@ class Application(ApplicationBase):
         self.validation_deployer = ChiasmaValidationDeployer(
             self, file_deployer, path_actions)
         self.deployer = ChiasmaDeployer(
-            self.path_properties, file_deployer, path_actions, os_service, branch_provider)
+            self.path_properties, file_deployer, path_actions, branch_provider)
 
     def build(self):
         super(Application, self).build()
@@ -44,9 +44,9 @@ class Application(ApplicationBase):
         super(Application, self).deploy_validation()
         self.validation_deployer.run()
 
-    def deploy(self):
-        super(Application, self).deploy()
-        self.deployer.run()
+    def deploy(self, skip_copy_backup):
+        super(Application, self).deploy(skip_copy_backup)
+        self.deployer.run(skip_copy_backup)
 
     def download_release_history(self):
         super(Application, self).download_release_history()

--- a/release_ccharp/cli.py
+++ b/release_ccharp/cli.py
@@ -67,11 +67,12 @@ def accept(ctx, repo):
 
 @cli.command("deploy")
 @click.argument("repo")
+@click.option("--skip-copy-backup", is_flag=True, default=False)
 @click.pass_context
-def deploy(ctx, repo):
+def deploy(ctx, repo, skip_copy_backup):
     factory = ApplicationFactory()
     instance = factory.get_instance(whatif=ctx.obj['whatif'], repo=repo)
-    instance.deploy()
+    instance.deploy(skip_copy_backup)
 
 
 @cli.command("download-release-history")

--- a/release_ccharp/repo.config
+++ b/release_ccharp/repo.config
@@ -4,15 +4,19 @@ chiasma :
     exe_file_name_base : Chiasma
     project_root_dir : Chiasma
     confluence_space_key : DOCCHI
+    db_backup_server_dir : \\130.238.178.226\Proc_references\Devel_backups\Latest release
+    db_backup_filename : gtdb2_devel_backup.bak
     owner : Molmed
     deploy_root_path : L:\Labsystem\Chiasma\Installation\Klient\Chiasma\Filer
 testing-repo :
-    root_path : C:\Tmp2
-    git_repo_name : FPdatabase
-    exe_file_name_base : FPDatabase
-    project_root_dir : FPDatabase_SourceCode
+    root_path : C:\Tmp
+    git_repo_name : testing-repo
+    exe_file_name_base : Chiasma
+    project_root_dir : Chiasma
+    db_backup_server_dir : \\130.238.178.226\Proc_references\Devel_backups\Latest release
+    db_backup_filename : gtdb2_devel_backup.bak
     owner : GitEdvard
-    deploy_root_path : C:\Tmp2\testing-repo-deploy
+    deploy_root_path : C:\Tmp\testing-repo-deploy
 order :
     root_path : P:\lims
     git_repo_name : PlattformOrdMan

--- a/release_ccharp/repo.config
+++ b/release_ccharp/repo.config
@@ -4,7 +4,7 @@ chiasma :
     exe_file_name_base : Chiasma
     project_root_dir : Chiasma
     confluence_space_key : DOCCHI
-    db_backup_server_dir : \\130.238.178.226\Proc_references\Devel_backups\Latest release
+    db_backup_server_dir : \\130.238.178.226\Latest release
     db_backup_filename : gtdb2_devel_backup.bak
     owner : Molmed
     deploy_root_path : L:\Labsystem\Chiasma\Installation\Klient\Chiasma\Filer
@@ -13,7 +13,7 @@ testing-repo :
     git_repo_name : testing-repo
     exe_file_name_base : Chiasma
     project_root_dir : Chiasma
-    db_backup_server_dir : \\130.238.178.226\Proc_references\Devel_backups\Latest release
+    db_backup_server_dir : \\130.238.178.226\Latest release
     db_backup_filename : gtdb2_devel_backup.bak
     owner : GitEdvard
     deploy_root_path : C:\Tmp\testing-repo-deploy

--- a/release_ccharp/snpseq_paths.py
+++ b/release_ccharp/snpseq_paths.py
@@ -188,6 +188,15 @@ class SnpseqPathProperties:
         return os.path.join(self.user_validations_latest, filename)
 
 
+    @property
+    def db_backup_server_dir(self):
+        return self.config['db_backup_server_dir']
+
+    @property
+    def db_backup_filename(self):
+        return self.config['db_backup_filename']
+
+
 class SnpseqPathActions:
     def __init__(self, whatif, path_properties, os_service, app_paths=None, windows_commands=None):
         self.path_properties = path_properties

--- a/tests/unit/chiasma_tests/base.py
+++ b/tests/unit/chiasma_tests/base.py
@@ -10,6 +10,8 @@ class ChiasmaBaseTests(BaseTests):
             "git_repo_name": "chiasma",
             "exe_file_name_base": "Chiasma",
             "project_root_dir" : "Chiasma",
+            'db_backup_server_dir' : r'server_dir',
+            'db_backup_filename' : 'gtdb2_devel_backup.bak',
             "owner": "GitEdvard",
             "deploy_root_path": r'c:\xxx\deploy'
         }


### PR DESCRIPTION
At deploy, fetch a database backup file from shared catalog on server, and copy it to the current candidate catalog. There is an option to skip this, if user has not access to the server path. 

Refactorings
* Add class for LogMixin, makes logging cleaner
