### PR TITLE
Reference to new MSbuild

### DIFF
--- a/release_ccharp/apps/common/base.py
+++ b/release_ccharp/apps/common/base.py
@@ -57,7 +57,8 @@ class ApplicationBase(object):
 
 class WindowsCommands:
     def build_solution(self, solution_file_path):
-        build_path = r'C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe'
+        #build_path = r'C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe'
+        build_path = r'C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe'
         print("build on solution file: {}".format(solution_file_path))
         cmd = [build_path, solution_file_path,
                r'/p:WarningLevel=0',

--- a/tests/integration/chiasma_deposit_tests.py
+++ b/tests/integration/chiasma_deposit_tests.py
@@ -1,0 +1,18 @@
+from __future__ import print_function
+import unittest
+from release_ccharp.apps.chiasmadeposit import Application
+from release_ccharp.utility.os_service import OsService
+from release_ccharp.snpseq_workflow import SnpseqWorkflow
+from release_ccharp.apps.common.base import WindowsCommands
+
+
+class ChiasmaDepositTests(unittest.TestCase):
+    def test_build_solution(self):
+        # Arrange
+        path2 = r'C:\GitRoot\ChiasmaDeposit\ChiasmaDeposit1.sln'
+        path = r'C:\Tmp2\Molmed-ChiasmaDeposit-9b13e94\ChiasmaDeposit1.sln'
+        path3 = r'C:\GitRoot\chiasma\Chiasma.sln'
+        windows_commands = WindowsCommands()
+
+        # Act
+        windows_commands.build_solution(path)


### PR DESCRIPTION
Use MSBuild for Visual Studio 2017. This path requires that Visual Studio is installed on the computer running release-ccharp.