### PR TITLE
chi-1025, New handling of transform config

### DIFF
--- a/release_ccharp/apps/chiasma_scripts/builder.py
+++ b/release_ccharp/apps/chiasma_scripts/builder.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import os
 from release_ccharp.exceptions import SnpseqReleaseException
-from release_ccharp.apps.common.single_file_read_write import StandardVSConfigXML
+from release_ccharp.apps.common.single_file_read_write import VsConfigOpener
 from release_ccharp.utils import create_dirs
 
 
@@ -48,8 +48,9 @@ class ChiasmaBuilder:
         config_file_path = os.path.join(directory, self.chiasma.app_paths.config_file_name)
         db_name = "GTDB2" if directory == self.chiasma.app_paths.production_dir else "GTDB2_practice"
         self.chiasma.save_backup_file(config_file_path)
-        with self.chiasma.open_xml(config_file_path) as xml:
-            config = StandardVSConfigXML(xml, "Molmed.Chiasma.Properties")
+        vs_config = VsConfigOpener(self.chiasma.os_service, self.chiasma.log,
+                                   "Molmed.Chiasma.Properties")
+        with vs_config.open(config_file_path) as config:
             config.update("EnforceAppVersion", "True")
             config.update("DilutePlateAutomaticLabelPrint", "True")
             config.update("DiluteTubeAutomaticLabelPrint", "True")
@@ -61,8 +62,9 @@ class ChiasmaBuilder:
                     self.chiasma.whatif)
         lab_config_file_path = os.path.join(lab_config_dir, self.chiasma.app_paths.config_file_name)
         self.chiasma.os_service.copyfile(config_file_path, lab_config_file_path)
-        with self.chiasma.open_xml(lab_config_file_path) as xml:
-            config = StandardVSConfigXML(xml, "Molmed.Chiasma.Properties")
+        vs_config = VsConfigOpener(self.chiasma.os_service, self.chiasma.log,
+                                   "Molmed.Chiasma.Properties")
+        with vs_config.open(lab_config_file_path) as config:
             config.update("ApplicationMode", "LAB")
 
     def transform_config(self):

--- a/tests/integration/chiasma_build_tests.py
+++ b/tests/integration/chiasma_build_tests.py
@@ -13,7 +13,8 @@ class ChiasmaBuildTests(unittest.TestCase):
             "root_path": r'c:\tmp',
             "git_repo_name": "chiasma",
             "confluence_space_key": "CHI",
-            "owner": "GitEdvard"
+            "owner": "GitEdvard",
+            "exe_file_name_base" : "Chiasma"
         }
         branch_provider = FakeBranchProvider()
         wf = SnpseqWorkflow(whatif=False, repo="chiasma", os_service=OsService())
@@ -59,7 +60,7 @@ class ChiasmaBuildTests(unittest.TestCase):
         self.chiasma.chiasma_builder.move_candidates()
         self.assertEqual(1,2)
 
-    @unittest.skip("")
+    #@unittest.skip("")
     def test_transform_config(self):
         self.chiasma.chiasma_builder.transform_config()
         self.assertEqual(1,2)

--- a/tests/unit/utility/config.py
+++ b/tests/unit/utility/config.py
@@ -4,6 +4,11 @@ import os
 def load_chiasma_config():
     return _load_file('chiasma.exe.config')
 
+def load_chiama_config_replacement_test():
+    return _load_file('chiasma.exe.config.replacetest')
+
+def load_chiama_config_transformed():
+    return _load_file('chiasma.exe.config.transformed')
 
 def load_chiasma_deposit_config():
     return _load_file('chiasma_deposit.exe.config')
@@ -30,6 +35,10 @@ def _load_file(file_name):
 
 
 CHIASMA_CONFIG = load_chiasma_config()
+
+CHIASMA_CONFIG_REPLACE_TEST = load_chiama_config_replacement_test()
+
+CHIASMA_CONFIG_TRANSFORMED = load_chiama_config_transformed()
 
 CHIASMA_DEPOSIT_CONFIG = load_chiasma_deposit_config()
 

--- a/tests/unit/utility/helpers.py
+++ b/tests/unit/utility/helpers.py
@@ -1,0 +1,10 @@
+import pyperclip
+
+
+def copy_to_clipboard(var):
+    if isinstance(var, set):
+        var = list(var)
+    if isinstance(var, list):
+        var = '\n\n'.join(var)
+    print('copied to clipboard:\n{}'.format(var))
+    pyperclip.copy('{}'.format(var))

--- a/tests/unit/utility/resources/chiasma.exe.config.replacetest
+++ b/tests/unit/utility/resources/chiasma.exe.config.replacetest
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <configSections>
+        <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <section name="Molmed.Chiasma.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+        </sectionGroup>
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    </configSections>
+    <applicationSettings>
+        <Molmed.Chiasma.Properties.Settings>
+replacement text</Molmed.Chiasma.Properties.Settings>
+    </applicationSettings>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="v11.0" />
+      </parameters>
+    </defaultConnectionFactory>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
+</configuration>

--- a/tests/unit/utility/resources/chiasma.exe.config.transformed
+++ b/tests/unit/utility/resources/chiasma.exe.config.transformed
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <configSections>
+        <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <section name="Molmed.Chiasma.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+        </sectionGroup>
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    </configSections>
+    <applicationSettings>
+        <Molmed.Chiasma.Properties.Settings>
+            <setting name="ApplicationMode" serializeAs="String">
+                <value>OFFICE</value>
+            </setting>
+            <setting name="RandomProperty" serializeAs="String">
+                <value>600</value>
+            </setting>
+            <setting name="DilutePlateAutomaticLabelPrint" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="DiluteTubeAutomaticLabelPrint" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="TestMode" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="DatabaseName" serializeAs="String">
+                <value>GTDB2_devel_{INITIALS}</value>
+            </setting>
+            <setting name="EnforceAppVersion" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="DebugMode" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="RepositoryImplementation" serializeAs="String">
+                <value>Datareader</value>
+            </setting>
+        </Molmed.Chiasma.Properties.Settings>
+    </applicationSettings>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="v11.0" />
+      </parameters>
+    </defaultConnectionFactory>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
+</configuration>

--- a/tests/unit/xml_tests.py
+++ b/tests/unit/xml_tests.py
@@ -1,0 +1,66 @@
+import unittest
+from unittest import skip
+from xml.etree import ElementTree as ET
+from xml.etree.ElementTree import ElementTree, Element, SubElement, QName, tostring
+from pyfakefs import fake_filesystem
+from release_ccharp.apps.common.single_file_read_write import VsConfigOpener
+from release_ccharp.apps.common.single_file_read_write import StandardVSConfigXML
+from tests.unit.utility.config import CHIASMA_CONFIG
+from tests.unit.utility.config import CHIASMA_CONFIG_REPLACE_TEST
+from tests.unit.utility.config import CHIASMA_CONFIG_TRANSFORMED
+from release_ccharp.apps.common.base import ApplicationBase
+from tests.unit.chiasma_tests.base import ChiasmaBaseTests
+from tests.unit.utility.helpers import copy_to_clipboard
+from tests.unit.utility.fake_os_service import FakeOsService
+from release_ccharp.utils import create_dirs
+
+
+class TestCopyTree(ChiasmaBaseTests):
+    def setUp(self):
+        self.setup_chiasma()
+        chiasma_config_path = (r'c:\xxx\chiasma\candidates\validation\chiasma.exe.config')
+        self.filesystem.CreateFile(chiasma_config_path, contents=CHIASMA_CONFIG)
+
+    def test_write_xml(self):
+        myns = 'http://myns.com'
+        top = Element('top')
+        foo = SubElement(top, '{http://unique.com}foo')
+
+        print(tostring(top))
+        self.assertEqual(1, 1)
+
+    def test_write_settings_section(self):
+        config_file_path = r'c:\xxx\chiasma\candidates\validation\chiasma.exe.config'
+        with self.chiasma.open_xml(config_file_path) as xml:
+            config = StandardVSConfigXML(xml, "Molmed.Chiasma.Properties")
+            settings_list = config.setting_list
+        node_list = [tostring(s) for s in settings_list]
+        for n in node_list:
+            print(n)
+        self.assertEqual(1, 1)
+
+    def test_replace_settings_section(self):
+        del1 = '<Molmed.Chiasma.Properties.Settings>'
+        del2 = '</Molmed.Chiasma.Properties.Settings>'
+        config_start = CHIASMA_CONFIG.decode('utf-8-sig')
+        first_part, second_part = config_start.split(del1)
+        _, last_part = second_part.split(del2)
+        transformed_xml = first_part + del1 + '\nreplacement text' + del2 + last_part
+        transformed_xml = transformed_xml.encode('utf-8')
+        self.assertEqual(CHIASMA_CONFIG_REPLACE_TEST, transformed_xml)
+
+    def test_open_config(self):
+        self.filesystem = fake_filesystem.FakeFilesystem()
+        os_service = FakeOsService(self.filesystem)
+        path= r'c:\xxx\configfile'
+        create_dirs(os_service, r'c:\xxx')
+        self.filesystem.CreateFile(path, contents=CHIASMA_CONFIG)
+        vs_config_opener = VsConfigOpener(os_service, None, "Molmed.Chiasma.Properties")
+        with vs_config_opener.open(path) as c:
+            c.update("EnforceAppVersion", "True")
+        with os_service.open(path, 'r') as f:
+            contents = f.read()
+        copy_to_clipboard(contents)
+        expected = ''.join(CHIASMA_CONFIG_TRANSFORMED.split())
+        actual = ''.join(contents.split())
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
Purpose:
When saving config file with python built in xml handler, some details are changed that visual studio don't handle. There is a namespace definition added at top of xml tree, and that causes visual studio to fail. 

Implementation:
Create new class VsConfigOpener, to replace open_xml in chiasma builder class. This class saves the config files by using the original config as text, then replace the application settings node. 

Test environment:
Add two transformed config files in test, to be used as expected strings in tests. Add new tests for xml reading.