### PR TITLE
chi-1050, Adapt for separate ChiasmaResultService services 

### DIFF
--- a/tests/unit/utility/resources/chiasma.exe.config
+++ b/tests/unit/utility/resources/chiasma.exe.config
@@ -35,6 +35,11 @@
             <setting name="RepositoryImplementation" serializeAs="String">
                 <value>Datareader</value>
             </setting>
+            <setting name="Chiasma_ResultWebServiceDevelopment_ResultWebService"
+                serializeAs="String">
+                <value>http://mm-wchs001:65203/ChiasmaResultServiceDevelopment/ResultWebService.asmx</value>
+            </setting>
+
         </Molmed.Chiasma.Properties.Settings>
     </applicationSettings>
   <startup>


### PR DESCRIPTION
Purpose:
There are now three separate web services for ChiasmaResultService, one for each environment Production, Validation and Development. Adpat app.settings so that the proper web service is referenced for validation and production environment respectively.
