### PR TITLE
chi-1075, Chiasma db reference moved to shared kernel

### DIFF
--- a/tests/unit/utility/config.py
+++ b/tests/unit/utility/config.py
@@ -4,6 +4,11 @@ import os
 def load_chiasma_config():
     return _load_file('chiasma.exe.config')
 
+
+def load_chiasma_shared_kernel_config():
+    return _load_file('chiasma.sharedkernel.exe.config')
+
+
 def load_chiama_config_replacement_test():
     return _load_file('chiasma.exe.config.replacetest')
 
@@ -39,6 +44,8 @@ def _load_file(file_name):
 
 
 CHIASMA_CONFIG = load_chiasma_config()
+
+CHIASMA_SHAREDKERNEL_CONFIG = load_chiasma_shared_kernel_config()
 
 CHIASMA_CONFIG_REPLACE_TEST = load_chiama_config_replacement_test()
 

--- a/tests/unit/utility/resources/chiasma.exe.config
+++ b/tests/unit/utility/resources/chiasma.exe.config
@@ -23,9 +23,6 @@
             <setting name="TestMode" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="DatabaseName" serializeAs="String">
-                <value>GTDB2_devel_{INITIALS}</value>
-            </setting>
             <setting name="EnforceAppVersion" serializeAs="String">
                 <value>False</value>
             </setting>

--- a/tests/unit/utility/resources/chiasma.exe.config.transformed
+++ b/tests/unit/utility/resources/chiasma.exe.config.transformed
@@ -35,6 +35,10 @@
             <setting name="RepositoryImplementation" serializeAs="String">
                 <value>Datareader</value>
             </setting>
+            <setting name="Chiasma_ResultWebServiceDevelopment_ResultWebService"
+                serializeAs="String">
+                <value>http://mm-wchs001:65203/ChiasmaResultServiceDevelopment/ResultWebService.asmx</value>
+            </setting>
         </Molmed.Chiasma.Properties.Settings>
     </applicationSettings>
   <startup>

--- a/tests/unit/utility/resources/chiasma.exe.config.transformed
+++ b/tests/unit/utility/resources/chiasma.exe.config.transformed
@@ -23,9 +23,6 @@
             <setting name="TestMode" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="DatabaseName" serializeAs="String">
-                <value>GTDB2_devel_{INITIALS}</value>
-            </setting>
             <setting name="EnforceAppVersion" serializeAs="String">
                 <value>True</value>
             </setting>

--- a/tests/unit/utility/resources/chiasma.sharedkernel.exe.config
+++ b/tests/unit/utility/resources/chiasma.sharedkernel.exe.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <configSections>
+        <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="Chiasma.SharedKernel.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    </startup>
+    <applicationSettings>
+        <Chiasma.SharedKernel.Properties.Settings>
+            <setting name="DatabaseName" serializeAs="String">
+                <value>GTDB2_devel_{INITIALS}</value>
+            </setting>
+        </Chiasma.SharedKernel.Properties.Settings>
+    </applicationSettings>
+</configuration>


### PR DESCRIPTION
Purpose:
The db reference setting is moved from the chiasma.config file to the chiasma.sharedkernel.config file. 

Implementation:
In Chiasma builder, separate _transfrom_config into two separate calls, each call updating a separate config target. 
