### PR TITLE
Add projman db reference to chiasma

### DIFF
--- a/release_ccharp/apps/chiasma_scripts/builder.py
+++ b/release_ccharp/apps/chiasma_scripts/builder.py
@@ -66,7 +66,7 @@ class ChiasmaBuilder:
         with vs_config.open(lab_config_file_path) as config:
             config.update("ApplicationMode", "LAB")
 
-    def _transform_shared_kernel_config(self, directory, db_name):
+    def _transform_shared_kernel_config(self, directory, db_name, projman_db_name):
         config_file_path = os.path.join(directory, 'chiasma.sharedkernel.exe.config')
 
         self.chiasma.save_backup_file(config_file_path)
@@ -74,12 +74,14 @@ class ChiasmaBuilder:
                                    "Chiasma.SharedKernel.Properties")
         with vs_config.open(config_file_path) as config:
             config.update("DatabaseName", db_name)
+            config.update("ProjmanDatabaseName", projman_db_name)
 
     def _transform_configs(self, directory):
         provider = TransformSettingsProvider(self.chiasma)
-        db_name, result_web_service = provider.fetch_env_dependent_variables(directory)
+        db_name, result_web_service, projman_db_name = \
+            provider.fetch_env_dependent_variables(directory)
         self._transform_config(directory, result_web_service)
-        self._transform_shared_kernel_config(directory, db_name)
+        self._transform_shared_kernel_config(directory, db_name, projman_db_name)
 
     def transform_config(self):
         self._transform_configs(self.chiasma.app_paths.production_dir)
@@ -94,10 +96,12 @@ class TransformSettingsProvider:
         if directory == self.chiasma.app_paths.production_dir:
             db_name = "GTDB2"
             result_web_service = self._web_result_service_production
+            projman_db_name = "ProjectMan"
         else:
             db_name = "GTDB2_practice"
             result_web_service = self._web_result_service_validation
-        return db_name, result_web_service
+            projman_db_name = "ProjectMan_devel"
+        return db_name, result_web_service, projman_db_name
 
     @property
     def _web_result_service_validation(self):

--- a/release_ccharp/apps/common/base.py
+++ b/release_ccharp/apps/common/base.py
@@ -62,7 +62,7 @@ class WindowsCommands:
         restore_nuget_cmd = ['nuget', r'restore', solution_file_path, r'-Verbosity', r'quiet']
         call(restore_nuget_cmd)
         print('Done.')
-        msbuild_path = r'C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe'
+        msbuild_path = r'C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBuild.exe'
         print("Calling msbuild on solution file: {}".format(solution_file_path))
         msbuild_cmd = [msbuild_path, solution_file_path,
                r'/p:WarningLevel=0',

--- a/tests/unit/chiasma_tests/chiasma_build_tests_unit.py
+++ b/tests/unit/chiasma_tests/chiasma_build_tests_unit.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import os
 from unittest import skip
+import pytest
 from pyfakefs.fake_filesystem import FakeFileOpen
 from release_ccharp.apps.common.single_file_read_write import StandardVSConfigXML
 from release_ccharp.utils import create_dirs
@@ -100,6 +101,7 @@ line 3"""
             self.assertEqual("False", config.get("DebugMode"))
             self.assertEqual("Ef", config.get("RepositoryImplementation"))
 
+    @pytest.mark.now
     def test_transform_config_for_shared_kernel__with_validation_dir__xml_update_ok(self):
         validation_dir = r'c:\xxx\chiasma\candidates\validation'
         self.chiasma.chiasma_builder._transform_configs(validation_dir)
@@ -107,6 +109,7 @@ line 3"""
         with self.chiasma.open_xml(config_file_path) as xml:
             config = StandardVSConfigXML(xml, "Chiasma.SharedKernel.Properties")
             self.assertEqual("GTDB2_practice", config.get("DatabaseName"))
+            self.assertEqual("ProjectMan_devel", config.get("ProjmanDatabaseName"))
 
     def test_transform_config__with_validation_directory__lab_config_update_ok(self):
         validation_dir = r'c:\xxx\chiasma\candidates\validation'
@@ -123,6 +126,7 @@ line 3"""
             self.assertEqual("False", config.get("DebugMode"))
             self.assertEqual("Ef", config.get("RepositoryImplementation"))
 
+    @pytest.mark.now
     def test_transform_shared_kernel_config__with_validation_directory__lab_config_update_ok(self):
         validation_dir = r'c:\xxx\chiasma\candidates\validation'
         self.chiasma.chiasma_builder._transform_configs(validation_dir)
@@ -131,6 +135,7 @@ line 3"""
         with self.chiasma.open_xml(config_file_path) as xml:
             config = StandardVSConfigXML(xml, "Chiasma.SharedKernel.Properties")
             self.assertEqual("GTDB2_practice", config.get("DatabaseName"))
+            self.assertEqual("ProjectMan_devel", config.get("ProjmanDatabaseName"))
 
     def test_update_binary_version__with_excerp_from_real_file__update_ok(self):
         original_contents = """row 1

--- a/tests/unit/utility/resources/chiasma.sharedkernel.exe.config
+++ b/tests/unit/utility/resources/chiasma.sharedkernel.exe.config
@@ -13,6 +13,12 @@
             <setting name="DatabaseName" serializeAs="String">
                 <value>GTDB2_devel_{INITIALS}</value>
             </setting>
+            <setting name="ProjmanDatabaseName" serializeAs="String">
+                <value>ProjectMan_devel_{INITIALS}</value>
+            </setting>
+            <setting name="ConnectionString" serializeAs="String">
+                <value>data source=130.238.178.226;integrated security=true;initial catalog=db_name;</value>
+            </setting>
         </Chiasma.SharedKernel.Properties.Settings>
     </applicationSettings>
 </configuration>


### PR DESCRIPTION
Purpose:

Chiasma now have a UI to maintain Tableau reference, mappning sequencer names and runfolder codes. This mapping is contained in the ProjectMan database. So therefore, the reference to the ProjectMan database is handled within release-ccharp.