### PR TITLE
Change to argos paths

### DIFF
--- a/release_ccharp/apps/chiasma_scripts/builder.py
+++ b/release_ccharp/apps/chiasma_scripts/builder.py
@@ -24,7 +24,11 @@ class ChiasmaBuilder:
         self.chiasma.binary_version_updater.update_binary_version(assembly_file_path)
 
     def check_build_not_already_run(self):
-        self.file_deployer.check_not_already_run()
+        if self.chiasma.os_service.exists(self.app_paths.production_dir) or \
+                self.chiasma.os_service.exists(self.app_paths.validation_dir):
+            raise SnpseqReleaseException(
+                ("Production or validation catalog already exists. " 
+                "They need to be removed before continuing"))
 
     def build_solution(self):
         solution_file = self._find_solution_file()

--- a/release_ccharp/apps/sqat_scripts/builder.py
+++ b/release_ccharp/apps/sqat_scripts/builder.py
@@ -28,7 +28,11 @@ class SqatBuilder:
         self.copy_user_manual()
 
     def check_not_already_run(self):
-        self.file_deployer.check_not_already_run()
+        if self.sqat.os_service.exists(self.app_paths.production_dir) or \
+                self.sqat.os_service.exists(self.app_paths.validation_dir):
+            raise SnpseqReleaseException(
+                ("Production or validation catalog already exists. "
+                 "They need to be removed before continuing"))
 
     def update_binary_version(self):
         self.binary_version_updater.update_binary_version(self._assembly_file_path)

--- a/release_ccharp/repo.config.txt
+++ b/release_ccharp/repo.config.txt
@@ -1,5 +1,5 @@
 chiasma :
-    root_path : P:\lims
+    root_path : G:\Silver\snpseq_info\lims
     local_root_path : C:\Tmp
     git_repo_name : chiasma
     exe_file_name_base : Chiasma
@@ -8,7 +8,7 @@ chiasma :
     db_backup_server_dir : \\130.238.178.226\Latest release
     db_backup_filename : gtdb2_devel_backup.bak
     owner : Molmed
-    deploy_root_path : L:\Labsystem\Chiasma\Installation\Klient\Chiasma\Filer
+    deploy_root_path : G:\Silver\snpseq_lab_general\Labsystem\Chiasma\Installation\Klient\Chiasma\Filer
 testing-repo :
     root_path : C:\Tmp
     local_root_path : C:\Tmp
@@ -18,7 +18,7 @@ testing-repo :
     owner : GitEdvard
     deploy_root_path : C:\Tmp\testing-repo-deploy
 order :
-    root_path : P:\lims
+    root_path : G:\Silver\snpseq_info\lims
     local_root_path : C:\Tmp
     git_repo_name : PlattformOrdMan
     exe_file_name_base : Order
@@ -26,29 +26,28 @@ order :
     db_backup_server_dir : \\130.238.178.226\Latest release
     db_backup_filename : order_devel_backup.bak
     owner : Molmed
-    deploy_root_path : L:\Labsystem\Chiasma\Installation\Klient\Order\Filer
+    deploy_root_path : G:\Silver\snpseq_lab_general\Labsystem\Chiasma\Installation\Klient\Order\Filer
 sqat:
-    root_path : P:\lims
+    root_path : G:\Silver\snpseq_info\lims
     local_root_path : C:\Tmp
     git_repo_name : SNPQualityAnalysisTool
     exe_file_name_base : SNP Quality Analysis Tool
     project_root_dir : SQAT3Client
     owner : Molmed
-    deploy_root_path : L:\Labsystem\Chiasma\Installation\Klient\SNP Quality Analysis Tool
+    deploy_root_path : G:\Silver\snpseq_lab_general\Labsystem\Chiasma\Installation\Klient\SNP Quality Analysis Tool
 fp:
-    root_path : P:\lims
+    root_path : G:\Silver\snpseq_info\lims
     local_root_path : C:\Tmp
     git_repo_name : FPdatabase
     exe_file_name_base : FPDatabase
     project_root_dir : FPDatabase_SourceCode
     owner : Molmed
-    deploy_root_path : L:\Labsystem\Chiasma\Installation\Klient\FPdatabase
+    deploy_root_path : G:\Silver\snpseq_lab_general\Labsystem\Chiasma\Installation\Klient\FPdatabase
 chiasmadeposit :
-    root_path : P:\lims
+    root_path : G:\Silver\snpseq_info\lims
     local_root_path : C:\Tmp
     git_repo_name : ChiasmaDeposit
     exe_file_name_base : ChiasmaDeposit
     project_root_dir : ChiasmaDeposit
     owner : Molmed
-    deploy_root_path : L:\Labsystem\Chiasma\Installation\Klient\ChiasmaDeposit
-
+    deploy_root_path : G:\Silver\snpseq_lab_general\Labsystem\Chiasma\Installation\Klient\ChiasmaDeposit

--- a/tests/unit/chiasma_tests/chiasma_build_tests_unit.py
+++ b/tests/unit/chiasma_tests/chiasma_build_tests_unit.py
@@ -4,6 +4,7 @@ from unittest import skip
 import pytest
 from pyfakefs.fake_filesystem import FakeFileOpen
 from release_ccharp.apps.common.single_file_read_write import StandardVSConfigXML
+from release_ccharp.exceptions import SnpseqReleaseException
 from release_ccharp.utils import create_dirs
 from tests.unit.utility.config import CHIASMA_CONFIG
 from tests.unit.utility.config import CHIASMA_SHAREDKERNEL_CONFIG
@@ -34,6 +35,11 @@ line 3"""
         (current, new) = self.chiasma.binary_version_updater.get_assembly_replace_strings(s, "1.0.0")
         self.assertEqual("assembly: AssemblyVersion(\"1.6.*\")", current)
         self.assertEqual("assembly: AssemblyVersion(\"1.0.0\")", new)
+
+    def test_production_folder_exists_render_error_message(self):
+        self.filesystem.create_file(r'c:\local\chiasma\candidates\release-1.0.0\production\chiasma.exe')
+        with self.assertRaises(SnpseqReleaseException):
+            self.chiasma.chiasma_builder.check_build_not_already_run()
 
     def test_read_file(self):
         print(CHIASMA_CONFIG)


### PR DESCRIPTION
Change release paths to the new G: partition (former P: and L: partitions). Also fix errors from the previous feature, parting local paths in build tasks, and common area for distributing executables. When check for if a path already exists, make sure the local path is checked for, not the common path. 